### PR TITLE
Add finetuning SDK

### DIFF
--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -77,13 +77,16 @@ def evaluate(ft, examples: list[dict]) -> float:
 
     correct = 0
     for example in examples:
-        group = ft.query_rollouts(
-            image=example["image"],
-            question=QUESTION,
-            num_rollouts=1,
-            settings=EVAL_SETTINGS,
+        response = ft.rollouts(
+            md.types.RolloutRequest(
+                skill="query",
+                image=example["image"],
+                question=QUESTION,
+                num_rollouts=1,
+                settings=EVAL_SETTINGS,
+            )
         )
-        answer = group.rollouts[0].get("answer", "")
+        answer = response["rollouts"][0]["output"].get("answer", "")
         correct += int(reward(answer, example["answer"]))
 
     return correct / len(examples)
@@ -136,18 +139,28 @@ def main():
     for _ in range(args.steps):
         example = next(train_examples)
 
-        rl_group = ft.query_rollouts(
-            image=example["image"],
-            question=QUESTION,
-            num_rollouts=args.num_rollouts,
-            settings=TRAIN_SETTINGS,
+        response = ft.rollouts(
+            md.types.RolloutRequest(
+                skill="query",
+                image=example["image"],
+                question=QUESTION,
+                num_rollouts=args.num_rollouts,
+                settings=TRAIN_SETTINGS,
+            )
         )
-        rl_group.rewards = [
-            reward(rollout["answer"], example["answer"]) for rollout in rl_group.rollouts
+        rewards = [
+            reward(rollout["output"].get("answer", ""), example["answer"])
+            for rollout in response["rollouts"]
         ]
+        rl_group: md.types.RLGroup = {
+            "mode": "rl",
+            "request": response["request"],
+            "rollouts": response["rollouts"],
+            "rewards": rewards,
+        }
 
         step = ft.train_step([rl_group], lr=args.lr)
-        reward_mean = sum(rl_group.rewards) / len(rl_group.rewards)
+        reward_mean = sum(rewards) / len(rewards)
         print(
             f"step={step['step']} label={example['answer']} reward_mean={reward_mean:.3f}",
             flush=True,

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -24,7 +24,6 @@ if str(REPO_ROOT) not in sys.path:
 import moondream as md
 
 API_KEY = os.environ["MOONDREAM_API_KEY"]
-HF_TOKEN = os.environ["HF_TOKEN"]
 
 QUESTION = "Is this rock, paper, or scissors? Respond with rock, paper, or scissors only."
 TRAIN_SETTINGS = {"temperature": 1.0, "top_p": 1.0, "max_tokens": 4}
@@ -48,17 +47,11 @@ def iter_examples(target_split: str):
         "real-rps",
         split="train",
         streaming=True,
-        token=HF_TOKEN,
     ).filter(lambda row: row.get("split", "").lower() == target_split)
 
     while True:
         for row in dataset:
-            label = row.get("class", "")
-            image = row.get("image")
-            if not label or image is None:
-                continue
-
-            yield {"image": image, "answer": label}
+            yield {"image": row["image"], "answer": row["class"]}
 
 
 def evaluate(ft, examples: list[dict]) -> float:

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -23,8 +23,6 @@ if str(REPO_ROOT) not in sys.path:
 
 import moondream as md
 
-API_KEY = os.environ["MOONDREAM_API_KEY"]
-
 QUESTION = "Is this rock, paper, or scissors? Respond with rock, paper, or scissors only."
 
 STEPS = 20
@@ -71,30 +69,30 @@ def evaluate(ft, examples: list[dict]) -> float:
     return correct / len(examples)
 
 
-def make_requests(examples):
-    for example in examples:
-        yield example, {
-            "skill": "query",
-            "image": example["image"],
-            "question": QUESTION,
-            "num_rollouts": NUM_ROLLOUTS,
-            "settings": {"temperature": 1.0, "max_tokens": 4},
-        }
-
-
 def main():
     train_examples = iter_examples("train")
     eval_examples = list(islice(iter_examples("valid"), EVAL_SAMPLES))
     assert eval_examples, "Could not load any eval examples"
 
     ft = md.ft(
-        api_key=API_KEY,
+        api_key=os.environ["MOONDREAM_API_KEY"],
         name=f"rps-query-{int(time.time())}",
         rank=RANK,
     )
     print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
 
-    for example, response in ft.rollout_stream(islice(make_requests(train_examples), STEPS)):
+    requests = (
+        (example, {
+            "skill": "query",
+            "image": example["image"],
+            "question": QUESTION,
+            "num_rollouts": NUM_ROLLOUTS,
+            "settings": {"temperature": 1.0, "max_tokens": 4},
+        })
+        for example in train_examples
+    )
+
+    for example, response in ft.rollout_stream(islice(requests, STEPS)):
         rewards = [
             reward(rollout["output"].get("answer", ""), example["answer"])
             for rollout in response["rollouts"]

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -46,26 +46,17 @@ def iter_examples(target_split: str):
     ).filter(lambda row: row.get("split", "").lower() == target_split)
 
     while True:
-        for row in dataset:
-            yield {"image": row["image"], "answer": row["class"]}
+        yield from dataset
 
 
-def evaluate(ft, examples: list[dict]) -> float:
-    if not examples:
-        return 0.0
-
-    correct = 0
-    for example in examples:
-        response = ft.rollouts(
-            "query",
-            image=example["image"],
-            question=QUESTION,
-            num_rollouts=1,
+def evaluate(ft, examples):
+    correct = sum(
+        ft.rollouts(
+            "query", image=ex["image"], question=QUESTION,
             settings={"temperature": 0.0, "max_tokens": 4},
-        )
-        answer = response["rollouts"][0]["output"].get("answer", "")
-        correct += int(reward(answer, example["answer"]))
-
+        )["rollouts"][0]["output"].get("answer", "").strip().lower() == ex["class"]
+        for ex in examples
+    )
     return correct / len(examples)
 
 
@@ -94,7 +85,7 @@ def main():
 
     for example, response in ft.rollout_stream(islice(requests, STEPS)):
         rewards = [
-            reward(rollout["output"].get("answer", ""), example["answer"])
+            reward(rollout["output"].get("answer", ""), example["class"])
             for rollout in response["rollouts"]
         ]
         step = ft.train_step([{
@@ -105,7 +96,7 @@ def main():
         }], lr=LR)
         reward_mean = sum(rewards) / len(rewards)
         print(
-            f"step={step['step']} label={example['answer']} reward_mean={reward_mean:.3f}",
+            f"step={step['step']} label={example['class']} reward_mean={reward_mean:.3f}",
             flush=True,
         )
 

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -23,6 +23,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 import moondream as md
+from moondream.finetune import DEFAULT_TUNING_ENDPOINT
 
 
 DATASET_NAME = "moondream/classification"
@@ -92,7 +93,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--api-key", default=os.getenv("MOONDREAM_API_KEY"))
     parser.add_argument("--hf-token", default=os.getenv("HF_TOKEN"))
-    parser.add_argument("--endpoint", default=md.DEFAULT_TUNING_ENDPOINT)
+    parser.add_argument("--endpoint", default=DEFAULT_TUNING_ENDPOINT)
     parser.add_argument("--rank", type=int, default=8)
     parser.add_argument("--steps", type=int, default=20)
     parser.add_argument("--num-rollouts", type=int, default=4)

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -136,30 +136,29 @@ def main():
 
     print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
 
-    for _ in range(args.steps):
-        example = next(train_examples)
-
-        response = ft.rollouts(
-            md.types.RolloutRequest(
+    def make_requests(examples, num_rollouts, settings):
+        for example in examples:
+            yield example, md.types.RolloutRequest(
                 skill="query",
                 image=example["image"],
                 question=QUESTION,
-                num_rollouts=args.num_rollouts,
-                settings=TRAIN_SETTINGS,
+                num_rollouts=num_rollouts,
+                settings=settings,
             )
-        )
+
+    requests = make_requests(train_examples, args.num_rollouts, TRAIN_SETTINGS)
+
+    for example, response in ft.rollout_stream(islice(requests, args.steps)):
         rewards = [
             reward(rollout["output"].get("answer", ""), example["answer"])
             for rollout in response["rollouts"]
         ]
-        rl_group: md.types.RLGroup = {
+        step = ft.train_step([{
             "mode": "rl",
             "request": response["request"],
             "rollouts": response["rollouts"],
             "rewards": rewards,
-        }
-
-        step = ft.train_step([rl_group], lr=args.lr)
+        }], lr=args.lr)
         reward_mean = sum(rewards) / len(rewards)
         print(
             f"step={step['step']} label={example['answer']} reward_mean={reward_mean:.3f}",

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -177,7 +177,8 @@ def main():
                 flush=True,
             )
 
-    checkpoint = ft.save_checkpoint()
+    save_result = ft.save_checkpoint()
+    checkpoint = save_result["checkpoint"]
     model_id = ft.model(checkpoint["step"])
 
     print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -26,12 +26,9 @@ import moondream as md
 API_KEY = os.environ["MOONDREAM_API_KEY"]
 HF_TOKEN = os.environ["HF_TOKEN"]
 
-DATASET_NAME = "moondream/classification"
-DATASET_SUBSET = "real-rps"
 QUESTION = "Is this rock, paper, or scissors? Respond with rock, paper, or scissors only."
 TRAIN_SETTINGS = {"temperature": 1.0, "top_p": 1.0, "max_tokens": 4}
 EVAL_SETTINGS = {"temperature": 0.0, "top_p": 1.0, "max_tokens": 4}
-VALID_LABELS = ("rock", "paper", "scissors")
 
 STEPS = 20
 NUM_ROLLOUTS = 4
@@ -41,36 +38,22 @@ LR = 0.001
 RANK = 8
 
 
-def normalize_label(text: str) -> str:
-    lowered = " ".join(text.strip().lower().split())
-    if "scissor" in lowered:
-        return "scissors"
-    for label in VALID_LABELS:
-        if label in lowered:
-            return label
-    return ""
-
-
 def reward(answer: str, expected: str) -> float:
-    return 1.0 if normalize_label(answer) == normalize_label(expected) else 0.0
+    return 1.0 if answer.strip().lower() == expected else 0.0
 
 
 def iter_examples(target_split: str):
     dataset = load_dataset(
-        DATASET_NAME,
-        DATASET_SUBSET,
+        "moondream/classification",
+        "real-rps",
         split="train",
         streaming=True,
         token=HF_TOKEN,
-    )
+    ).filter(lambda row: row.get("split", "").lower() == target_split)
 
     while True:
         for row in dataset:
-            row_split = str(row.get("split", "")).lower()
-            if row_split != target_split:
-                continue
-
-            label = normalize_label(str(row.get("class", "")))
+            label = row.get("class", "")
             image = row.get("image")
             if not label or image is None:
                 continue

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -1,0 +1,174 @@
+"""Simple query finetuning example for rock/paper/scissors classification.
+
+Dataset: moondream/classification (subset real-rps)
+
+Requires:
+    pip install datasets pillow
+
+Set `MOONDREAM_API_KEY` and `HF_TOKEN`, or pass them via flags.
+"""
+
+import argparse
+import os
+import sys
+import time
+from itertools import islice
+from pathlib import Path
+
+from datasets import load_dataset
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import moondream as md
+
+
+DATASET_NAME = "moondream/classification"
+DATASET_SUBSET = "real-rps"
+QUESTION = "Is this rock, paper, or scissors? Respond with rock, paper, or scissors only."
+TRAIN_SETTINGS = {"temperature": 1.0, "top_p": 1.0, "max_tokens": 4}
+EVAL_SETTINGS = {"temperature": 0.0, "top_p": 1.0, "max_tokens": 4}
+VALID_LABELS = ("rock", "paper", "scissors")
+
+
+def normalize_label(text: str) -> str:
+    lowered = " ".join(text.strip().lower().split())
+    if "scissor" in lowered:
+        return "scissors"
+    for label in VALID_LABELS:
+        if label in lowered:
+            return label
+    return ""
+
+
+def reward(answer: str, expected: str) -> float:
+    return 1.0 if normalize_label(answer) == normalize_label(expected) else 0.0
+
+
+def iter_examples(target_split: str, hf_token: str):
+    dataset = load_dataset(
+        DATASET_NAME,
+        DATASET_SUBSET,
+        split="train",
+        streaming=True,
+        token=hf_token,
+    )
+
+    while True:
+        for row in dataset:
+            row_split = str(row.get("split", "")).lower()
+            if row_split != target_split:
+                continue
+
+            label = normalize_label(str(row.get("class", "")))
+            image = row.get("image")
+            if not label or image is None:
+                continue
+
+            yield {"image": image, "answer": label}
+
+
+def evaluate(ft, examples: list[dict]) -> float:
+    if not examples:
+        return 0.0
+
+    correct = 0
+    for example in examples:
+        group = ft.query_rollouts(
+            image=example["image"],
+            question=QUESTION,
+            num_rollouts=1,
+            settings=EVAL_SETTINGS,
+        )
+        answer = group.rollouts[0].get("answer", "")
+        correct += int(reward(answer, example["answer"]))
+
+    return correct / len(examples)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-key", default=os.getenv("MOONDREAM_API_KEY"))
+    parser.add_argument("--hf-token", default=os.getenv("HF_TOKEN"))
+    parser.add_argument("--endpoint", default=md.DEFAULT_TUNING_ENDPOINT)
+    parser.add_argument("--rank", type=int, default=8)
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--num-rollouts", type=int, default=4)
+    parser.add_argument("--eval-every", type=int, default=5)
+    parser.add_argument("--eval-samples", type=int, default=16)
+    parser.add_argument("--lr", type=float, default=0.001)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if not args.api_key:
+        raise SystemExit("Pass --api-key or set MOONDREAM_API_KEY")
+    if not args.hf_token:
+        raise SystemExit("Pass --hf-token or set HF_TOKEN")
+    if args.steps < 1:
+        raise SystemExit("--steps must be at least 1")
+    if args.num_rollouts < 1 or args.num_rollouts > 16:
+        raise SystemExit("--num-rollouts must be between 1 and 16")
+    if args.eval_every < 1:
+        raise SystemExit("--eval-every must be at least 1")
+    if args.eval_samples < 1:
+        raise SystemExit("--eval-samples must be at least 1")
+
+    train_examples = iter_examples("train", args.hf_token)
+    eval_examples = list(islice(iter_examples("valid", args.hf_token), args.eval_samples))
+    if not eval_examples:
+        raise SystemExit("Could not load any eval examples")
+
+    finetune_name = f"rps-query-{int(time.time())}"
+    ft = md.ft(
+        api_key=args.api_key,
+        name=finetune_name,
+        rank=args.rank,
+        endpoint=args.endpoint,
+    )
+
+    print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
+
+    for _ in range(args.steps):
+        example = next(train_examples)
+
+        rl_group = ft.query_rollouts(
+            image=example["image"],
+            question=QUESTION,
+            num_rollouts=args.num_rollouts,
+            settings=TRAIN_SETTINGS,
+        )
+        rl_group.rewards = [
+            reward(rollout["answer"], example["answer"]) for rollout in rl_group.rollouts
+        ]
+
+        step = ft.train_step([rl_group], lr=args.lr)
+        reward_mean = sum(rl_group.rewards) / len(rl_group.rewards)
+        print(
+            f"step={step['step']} label={example['answer']} reward_mean={reward_mean:.3f}",
+            flush=True,
+        )
+
+        if step["step"] % args.eval_every == 0 or step["step"] == args.steps:
+            eval_accuracy = evaluate(ft, eval_examples)
+            metrics = ft.log_metrics(
+                step=step["step"],
+                metrics={"eval/accuracy": eval_accuracy},
+            )
+            print(
+                f"eval step={metrics['step']} accuracy={eval_accuracy:.3f} logged={metrics['logged_count']}",
+                flush=True,
+            )
+
+    checkpoint = ft.save_checkpoint()
+    model_id = ft.model(checkpoint["step"])
+
+    print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)
+    print(f"Model ID: {model_id}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -5,10 +5,9 @@ Dataset: moondream/classification (subset real-rps)
 Requires:
     pip install datasets pillow
 
-Set `MOONDREAM_API_KEY` and `HF_TOKEN`, or pass them via flags.
+Set MOONDREAM_API_KEY and HF_TOKEN environment variables.
 """
 
-import argparse
 import os
 import sys
 import time
@@ -23,8 +22,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 import moondream as md
-from moondream.finetune import DEFAULT_TUNING_ENDPOINT
 
+API_KEY = os.environ["MOONDREAM_API_KEY"]
+HF_TOKEN = os.environ["HF_TOKEN"]
 
 DATASET_NAME = "moondream/classification"
 DATASET_SUBSET = "real-rps"
@@ -32,6 +32,13 @@ QUESTION = "Is this rock, paper, or scissors? Respond with rock, paper, or sciss
 TRAIN_SETTINGS = {"temperature": 1.0, "top_p": 1.0, "max_tokens": 4}
 EVAL_SETTINGS = {"temperature": 0.0, "top_p": 1.0, "max_tokens": 4}
 VALID_LABELS = ("rock", "paper", "scissors")
+
+STEPS = 20
+NUM_ROLLOUTS = 4
+EVAL_EVERY = 5
+EVAL_SAMPLES = 16
+LR = 0.001
+RANK = 8
 
 
 def normalize_label(text: str) -> str:
@@ -48,13 +55,13 @@ def reward(answer: str, expected: str) -> float:
     return 1.0 if normalize_label(answer) == normalize_label(expected) else 0.0
 
 
-def iter_examples(target_split: str, hf_token: str):
+def iter_examples(target_split: str):
     dataset = load_dataset(
         DATASET_NAME,
         DATASET_SUBSET,
         split="train",
         streaming=True,
-        token=hf_token,
+        token=HF_TOKEN,
     )
 
     while True:
@@ -78,13 +85,11 @@ def evaluate(ft, examples: list[dict]) -> float:
     correct = 0
     for example in examples:
         response = ft.rollouts(
-            md.types.RolloutRequest(
-                skill="query",
-                image=example["image"],
-                question=QUESTION,
-                num_rollouts=1,
-                settings=EVAL_SETTINGS,
-            )
+            "query",
+            image=example["image"],
+            question=QUESTION,
+            num_rollouts=1,
+            settings=EVAL_SETTINGS,
         )
         answer = response["rollouts"][0]["output"].get("answer", "")
         correct += int(reward(answer, example["answer"]))
@@ -92,53 +97,30 @@ def evaluate(ft, examples: list[dict]) -> float:
     return correct / len(examples)
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--api-key", default=os.getenv("MOONDREAM_API_KEY"))
-    parser.add_argument("--hf-token", default=os.getenv("HF_TOKEN"))
-    parser.add_argument("--endpoint", default=DEFAULT_TUNING_ENDPOINT)
-    parser.add_argument("--rank", type=int, default=8)
-    parser.add_argument("--steps", type=int, default=20)
-    parser.add_argument("--num-rollouts", type=int, default=4)
-    parser.add_argument("--eval-every", type=int, default=5)
-    parser.add_argument("--eval-samples", type=int, default=16)
-    parser.add_argument("--lr", type=float, default=0.001)
-    return parser.parse_args()
+def make_requests(examples):
+    for example in examples:
+        yield example, {
+            "skill": "query",
+            "image": example["image"],
+            "question": QUESTION,
+            "num_rollouts": NUM_ROLLOUTS,
+            "settings": TRAIN_SETTINGS,
+        }
 
 
 def main():
-    args = parse_args()
-    assert args.api_key, "Pass --api-key or set MOONDREAM_API_KEY"
-    assert args.hf_token, "Pass --hf-token or set HF_TOKEN"
+    train_examples = iter_examples("train")
+    eval_examples = list(islice(iter_examples("valid"), EVAL_SAMPLES))
+    assert eval_examples, "Could not load any eval examples"
 
-    train_examples = iter_examples("train", args.hf_token)
-    eval_examples = list(islice(iter_examples("valid", args.hf_token), args.eval_samples))
-    if not eval_examples:
-        raise SystemExit("Could not load any eval examples")
-
-    finetune_name = f"rps-query-{int(time.time())}"
     ft = md.ft(
-        api_key=args.api_key,
-        name=finetune_name,
-        rank=args.rank,
-        endpoint=args.endpoint,
+        api_key=API_KEY,
+        name=f"rps-query-{int(time.time())}",
+        rank=RANK,
     )
-
     print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
 
-    def make_requests(examples, num_rollouts, settings):
-        for example in examples:
-            yield example, md.types.RolloutRequest(
-                skill="query",
-                image=example["image"],
-                question=QUESTION,
-                num_rollouts=num_rollouts,
-                settings=settings,
-            )
-
-    requests = make_requests(train_examples, args.num_rollouts, TRAIN_SETTINGS)
-
-    for example, response in ft.rollout_stream(islice(requests, args.steps)):
+    for example, response in ft.rollout_stream(islice(make_requests(train_examples), STEPS)):
         rewards = [
             reward(rollout["output"].get("answer", ""), example["answer"])
             for rollout in response["rollouts"]
@@ -148,14 +130,14 @@ def main():
             "request": response["request"],
             "rollouts": response["rollouts"],
             "rewards": rewards,
-        }], lr=args.lr)
+        }], lr=LR)
         reward_mean = sum(rewards) / len(rewards)
         print(
             f"step={step['step']} label={example['answer']} reward_mean={reward_mean:.3f}",
             flush=True,
         )
 
-        if step["step"] % args.eval_every == 0 or step["step"] == args.steps:
+        if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
             eval_accuracy = evaluate(ft, eval_examples)
             metrics = ft.log_metrics(
                 step=step["step"],

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -108,18 +108,8 @@ def parse_args():
 
 def main():
     args = parse_args()
-    if not args.api_key:
-        raise SystemExit("Pass --api-key or set MOONDREAM_API_KEY")
-    if not args.hf_token:
-        raise SystemExit("Pass --hf-token or set HF_TOKEN")
-    if args.steps < 1:
-        raise SystemExit("--steps must be at least 1")
-    if args.num_rollouts < 1 or args.num_rollouts > 16:
-        raise SystemExit("--num-rollouts must be between 1 and 16")
-    if args.eval_every < 1:
-        raise SystemExit("--eval-every must be at least 1")
-    if args.eval_samples < 1:
-        raise SystemExit("--eval-samples must be at least 1")
+    assert args.api_key, "Pass --api-key or set MOONDREAM_API_KEY"
+    assert args.hf_token, "Pass --hf-token or set HF_TOKEN"
 
     train_examples = iter_examples("train", args.hf_token)
     eval_examples = list(islice(iter_examples("valid", args.hf_token), args.eval_samples))

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -26,8 +26,6 @@ import moondream as md
 API_KEY = os.environ["MOONDREAM_API_KEY"]
 
 QUESTION = "Is this rock, paper, or scissors? Respond with rock, paper, or scissors only."
-TRAIN_SETTINGS = {"temperature": 1.0, "top_p": 1.0, "max_tokens": 4}
-EVAL_SETTINGS = {"temperature": 0.0, "top_p": 1.0, "max_tokens": 4}
 
 STEPS = 20
 NUM_ROLLOUTS = 4
@@ -65,7 +63,7 @@ def evaluate(ft, examples: list[dict]) -> float:
             image=example["image"],
             question=QUESTION,
             num_rollouts=1,
-            settings=EVAL_SETTINGS,
+            settings={"temperature": 0.0, "max_tokens": 4},
         )
         answer = response["rollouts"][0]["output"].get("answer", "")
         correct += int(reward(answer, example["answer"]))
@@ -80,7 +78,7 @@ def make_requests(examples):
             "image": example["image"],
             "question": QUESTION,
             "num_rollouts": NUM_ROLLOUTS,
-            "settings": TRAIN_SETTINGS,
+            "settings": {"temperature": 1.0, "max_tokens": 4},
         }
 
 

--- a/examples/train_rps_query.py
+++ b/examples/train_rps_query.py
@@ -11,7 +11,7 @@ Set MOONDREAM_API_KEY and HF_TOKEN environment variables.
 import os
 import sys
 import time
-from itertools import islice
+from itertools import cycle
 from pathlib import Path
 
 from datasets import load_dataset
@@ -28,42 +28,31 @@ QUESTION = "Is this rock, paper, or scissors? Respond with rock, paper, or sciss
 STEPS = 20
 NUM_ROLLOUTS = 4
 EVAL_EVERY = 5
-EVAL_SAMPLES = 16
 LR = 0.001
 RANK = 8
 
 
-def reward(answer: str, expected: str) -> float:
-    return 1.0 if answer.strip().lower() == expected else 0.0
-
-
-def iter_examples(target_split: str):
-    dataset = load_dataset(
-        "moondream/classification",
-        "real-rps",
-        split="train",
-        streaming=True,
-    ).filter(lambda row: row.get("split", "").lower() == target_split)
-
-    while True:
-        yield from dataset
+def load_examples(target_split):
+    return load_dataset(
+        "moondream/classification", "real-rps", split="train"
+    ).filter(lambda row: row["split"] == target_split)
 
 
 def evaluate(ft, examples):
-    correct = sum(
-        ft.rollouts(
+    correct, total = 0, 0
+    for ex in examples:
+        answer = ft.rollouts(
             "query", image=ex["image"], question=QUESTION,
             settings={"temperature": 0.0, "max_tokens": 4},
-        )["rollouts"][0]["output"].get("answer", "").strip().lower() == ex["class"]
-        for ex in examples
-    )
-    return correct / len(examples)
+        )["rollouts"][0]["output"]["answer"]
+        correct += answer.strip().lower() == ex["class"]
+        total += 1
+    return correct / total
 
 
 def main():
-    train_examples = iter_examples("train")
-    eval_examples = list(islice(iter_examples("valid"), EVAL_SAMPLES))
-    assert eval_examples, "Could not load any eval examples"
+    train_examples = load_examples("train")
+    eval_examples = load_examples("valid")
 
     ft = md.ft(
         api_key=os.environ["MOONDREAM_API_KEY"],
@@ -80,13 +69,13 @@ def main():
             "num_rollouts": NUM_ROLLOUTS,
             "settings": {"temperature": 1.0, "max_tokens": 4},
         })
-        for example in train_examples
+        for example in cycle(train_examples)
     )
 
-    for example, response in ft.rollout_stream(islice(requests, STEPS)):
+    for _, (example, response) in zip(range(STEPS), ft.rollout_stream(requests)):
         rewards = [
-            reward(rollout["output"].get("answer", ""), example["class"])
-            for rollout in response["rollouts"]
+            float(r["output"]["answer"].strip().lower() == example["class"])
+            for r in response["rollouts"]
         ]
         step = ft.train_step([{
             "mode": "rl",

--- a/moondream/__init__.py
+++ b/moondream/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from .cloud_vl import CloudVL
 from .finetune import DEFAULT_TUNING_ENDPOINT, FinetuneAPIError, ft
-from .types import RLGroup, RolloutSpec, SFTGroup
+from .types import RLGroup, RolloutGroup, SFTGroup
 
 __version__ = _pkg_version("moondream")
 
@@ -41,7 +41,7 @@ __all__ = [
     "DEFAULT_TUNING_ENDPOINT",
     "FinetuneAPIError",
     "RLGroup",
-    "RolloutSpec",
+    "RolloutGroup",
     "SFTGroup",
     "ft",
     "vl",

--- a/moondream/__init__.py
+++ b/moondream/__init__.py
@@ -1,9 +1,9 @@
 from importlib.metadata import version as _pkg_version
 from typing import Optional
 
+from . import types
 from .cloud_vl import CloudVL
-from .finetune import DEFAULT_TUNING_ENDPOINT, FinetuneAPIError, ft
-from .types import RLGroup, RolloutGroup, SFTGroup
+from .finetune import ft
 
 __version__ = _pkg_version("moondream")
 
@@ -36,14 +36,4 @@ def vl(
     return CloudVL(api_key=api_key, endpoint=endpoint, model=model, **kwargs)
 
 
-__all__ = [
-    "DEFAULT_ENDPOINT",
-    "DEFAULT_TUNING_ENDPOINT",
-    "FinetuneAPIError",
-    "RLGroup",
-    "RolloutGroup",
-    "SFTGroup",
-    "ft",
-    "vl",
-    "__version__",
-]
+__all__ = ["ft", "vl", "__version__"]

--- a/moondream/__init__.py
+++ b/moondream/__init__.py
@@ -2,6 +2,8 @@ from importlib.metadata import version as _pkg_version
 from typing import Optional
 
 from .cloud_vl import CloudVL
+from .finetune import DEFAULT_TUNING_ENDPOINT, FinetuneAPIError, ft
+from .types import RLGroup, RolloutSpec, SFTGroup
 
 __version__ = _pkg_version("moondream")
 
@@ -34,4 +36,14 @@ def vl(
     return CloudVL(api_key=api_key, endpoint=endpoint, model=model, **kwargs)
 
 
-__all__ = ["vl", "__version__"]
+__all__ = [
+    "DEFAULT_ENDPOINT",
+    "DEFAULT_TUNING_ENDPOINT",
+    "FinetuneAPIError",
+    "RLGroup",
+    "RolloutSpec",
+    "SFTGroup",
+    "ft",
+    "vl",
+    "__version__",
+]

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -52,26 +52,20 @@ class FinetuneAPIError(RuntimeError):
         self.body = body
 
 
-def _image_to_jpeg_bytes(image) -> bytes:
-    if isinstance(image, Image.Image):
-        try:
-            if image.mode != "RGB":
-                image = image.convert("RGB")
-            buffered = BytesIO()
-            image.save(buffered, format="JPEG", quality=95)
-            return buffered.getvalue()
-        except Exception as exc:
-            raise ValueError("Failed to convert image to JPEG.") from exc
-
-    raise ValueError(f"Unsupported EncodedImage type: {type(image)}")
-
-
 def _encode_image(image) -> Base64EncodedImage:
     if isinstance(image, Base64EncodedImage):
         return image
-    image_bytes = _image_to_jpeg_bytes(image)
-    img_str = base64.b64encode(image_bytes).decode()
-    return Base64EncodedImage(image_url=f"data:image/jpeg;base64,{img_str}")
+    if not isinstance(image, Image.Image):
+        raise ValueError(f"Unsupported image type: {type(image)}")
+    try:
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        buffered = BytesIO()
+        image.save(buffered, format="JPEG", quality=95)
+        img_str = base64.b64encode(buffered.getvalue()).decode()
+        return Base64EncodedImage(image_url=f"data:image/jpeg;base64,{img_str}")
+    except Exception as exc:
+        raise ValueError("Failed to convert image to JPEG.") from exc
 
 
 def _error_message(exc: urllib.error.HTTPError) -> str:
@@ -268,17 +262,6 @@ class Finetune:
         if request.ground_truth is not None:
             payload["ground_truth"] = dict(request.ground_truth)
         return payload
-
-    def _rl_group_from_response(self, response: RolloutsResponse) -> RLGroup:
-        group: RLGroup = {
-            "mode": "rl",
-            "request": response["request"],
-            "rollouts": response.get("rollouts", []),
-        }
-        rewards = response.get("rewards")
-        if rewards is not None:
-            group["rewards"] = rewards
-        return group
 
     def rollouts(self, request: RolloutRequest) -> RolloutsResponse:
         """Generate rollouts for a single request.

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -1,0 +1,709 @@
+import asyncio
+import base64
+import json
+import random
+import re
+import socket
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from io import BytesIO
+from importlib.metadata import version as _pkg_version
+from typing import Dict, List, Optional, Sequence
+
+from PIL import Image
+
+from .types import (
+    Base64EncodedImage,
+    CheckpointDownload,
+    CheckpointInfo,
+    CheckpointListOutput,
+    DetectFinetuneRequest,
+    DetectGroundTruth,
+    DetectTarget,
+    FinetuneSamplingSettings,
+    FinetuneGroundTruth,
+    FinetuneInfo,
+    FinetuneRequest,
+    PointFinetuneRequest,
+    PointGroundTruth,
+    PointTarget,
+    QueryFinetuneRequest,
+    QueryTarget,
+    RLGroup,
+    RolloutSpec,
+    SFTGroup,
+    TrainStepOutput,
+)
+
+__version__ = _pkg_version("moondream")
+
+DEFAULT_TUNING_ENDPOINT = "https://api.moondream.ai/v1/tuning"
+
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504, 524}
+_TRAIN_STEP_OUTPUT_KEYS = (
+    "step",
+    "applied",
+    "kl",
+    "router_kl",
+    "grad_norm",
+    "sft_loss",
+    "reward_mean",
+    "reward_std",
+)
+
+
+class FinetuneAPIError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: Optional[int] = None,
+        body: Optional[object] = None,
+    ):
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _image_to_jpeg_bytes(image) -> bytes:
+    if isinstance(image, Base64EncodedImage):
+        data = image.image_url
+        if data.startswith("data:"):
+            data = data.split(",", 1)[1]
+        return base64.b64decode(data)
+
+    if isinstance(image, Image.Image):
+        try:
+            if image.mode != "RGB":
+                image = image.convert("RGB")
+            buffered = BytesIO()
+            image.save(buffered, format="JPEG", quality=95)
+            return buffered.getvalue()
+        except Exception as exc:
+            raise ValueError("Failed to convert image to JPEG.") from exc
+
+    raise ValueError(f"Unsupported EncodedImage type: {type(image)}")
+
+
+def _encode_image(image) -> Base64EncodedImage:
+    if isinstance(image, Base64EncodedImage):
+        return image
+    image_bytes = _image_to_jpeg_bytes(image)
+    img_str = base64.b64encode(image_bytes).decode()
+    return Base64EncodedImage(image_url=f"data:image/jpeg;base64,{img_str}")
+
+
+def _retry_after_seconds(headers) -> Optional[float]:
+    value = headers.get("Retry-After") if headers is not None else None
+    if value is None:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        return None
+
+
+def _error_message(exc: urllib.error.HTTPError) -> str:
+    body = ""
+    try:
+        body = exc.read().decode("utf-8")
+    except Exception:
+        body = ""
+
+    if body:
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            for key in ("error", "message", "detail"):
+                value = parsed.get(key)
+                if isinstance(value, str) and value:
+                    return value
+        if body.strip():
+            return body.strip()
+
+    return exc.reason if isinstance(exc.reason, str) else str(exc.reason)
+
+
+def _is_retryable_error(exc: Exception) -> bool:
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code in _RETRY_STATUS_CODES
+    if isinstance(exc, urllib.error.URLError):
+        return True
+    return isinstance(exc, (TimeoutError, socket.timeout))
+
+
+def _raise_http_error(path: str, exc: urllib.error.HTTPError):
+    message = _error_message(exc)
+    raise FinetuneAPIError(
+        f"{path} failed with status {exc.code}: {message}",
+        status=exc.code,
+        body=message,
+    ) from exc
+
+
+class Finetune:
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str],
+        endpoint: str,
+        finetune_id: str,
+        name: str,
+        rank: int,
+        max_retries: int = 5,
+        retry_base_delay: float = 0.5,
+        retry_max_delay: float = 8.0,
+        timeout: float = 60.0,
+    ):
+        if max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+        if retry_base_delay < 0:
+            raise ValueError("retry_base_delay must be non-negative")
+        if retry_max_delay < 0:
+            raise ValueError("retry_max_delay must be non-negative")
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        self.api_key = api_key
+        self.endpoint = endpoint.rstrip("/")
+        self.finetune_id = finetune_id
+        self.name = name
+        self.rank = rank
+        self.max_retries = max_retries
+        self.retry_base_delay = retry_base_delay
+        self.retry_max_delay = retry_max_delay
+        self.timeout = timeout
+
+    def _headers(self, has_body: bool = False) -> Dict[str, str]:
+        headers = {
+            "User-Agent": f"moondream-python/{__version__}",
+        }
+        if has_body:
+            headers["Content-Type"] = "application/json"
+        if self.api_key:
+            headers["X-Moondream-Auth"] = self.api_key
+        return headers
+
+    def _url(self, path: str, query: Optional[dict] = None) -> str:
+        url = f"{self.endpoint}{path}"
+        if query:
+            items = [(k, v) for k, v in query.items() if v is not None]
+            if items:
+                url = f"{url}?{urllib.parse.urlencode(items)}"
+        return url
+
+    def _request_json_once(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[dict] = None,
+        query: Optional[dict] = None,
+    ) -> dict:
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self._url(path, query=query),
+            data=data,
+            headers=self._headers(has_body=payload is not None),
+            method=method,
+        )
+
+        with urllib.request.urlopen(req, timeout=self.timeout) as response:
+            body = response.read()
+            if not body:
+                return {}
+            return json.loads(body.decode("utf-8"))
+
+    def _backoff_delay(self, attempt: int, exc: Exception) -> float:
+        if isinstance(exc, urllib.error.HTTPError):
+            retry_after = _retry_after_seconds(exc.headers)
+            if retry_after is not None:
+                return retry_after
+        max_delay = min(self.retry_max_delay, self.retry_base_delay * (2 ** attempt))
+        return random.uniform(0.0, max_delay)
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[dict] = None,
+        query: Optional[dict] = None,
+    ) -> dict:
+        last_error: Optional[Exception] = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                return self._request_json_once(method, path, payload=payload, query=query)
+            except Exception as exc:
+                last_error = exc
+                if not _is_retryable_error(exc) or attempt == self.max_retries:
+                    if isinstance(exc, urllib.error.HTTPError):
+                        _raise_http_error(path, exc)
+                    raise FinetuneAPIError(f"{path} failed: {exc}") from exc
+                time.sleep(self._backoff_delay(attempt, exc))
+
+        raise FinetuneAPIError(f"{path} failed: {last_error}")
+
+    async def _request_json_async(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[dict] = None,
+        query: Optional[dict] = None,
+    ) -> dict:
+        last_error: Optional[Exception] = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                return await asyncio.to_thread(
+                    self._request_json_once,
+                    method,
+                    path,
+                    payload,
+                    query,
+                )
+            except Exception as exc:
+                last_error = exc
+                if not _is_retryable_error(exc) or attempt == self.max_retries:
+                    if isinstance(exc, urllib.error.HTTPError):
+                        _raise_http_error(path, exc)
+                    raise FinetuneAPIError(f"{path} failed: {exc}") from exc
+                await asyncio.sleep(self._backoff_delay(attempt, exc))
+
+        raise FinetuneAPIError(f"{path} failed: {last_error}")
+
+    def _validate_rollout_settings(
+        self, skill: str, settings: Optional[FinetuneSamplingSettings]
+    ) -> Optional[dict]:
+        if settings is None:
+            return None
+        settings_dict = dict(settings)
+        if skill == "query" and "max_objects" in settings_dict:
+            raise ValueError("query settings do not accept max_objects")
+        if skill in ("point", "detect") and "max_tokens" in settings_dict:
+            raise ValueError(f"{skill} settings do not accept max_tokens")
+        return settings_dict
+
+    def _serialize_request(self, request: FinetuneRequest) -> dict:
+        skill = request.get("skill")
+        if skill == "query":
+            return self._serialize_query_request(request)
+        if skill == "point":
+            return self._serialize_point_request(request)
+        if skill == "detect":
+            return self._serialize_detect_request(request)
+        raise ValueError("request.skill must be one of 'query', 'point', or 'detect'")
+
+    def _serialize_query_request(self, request: QueryFinetuneRequest) -> dict:
+        question = request.get("question")
+        if question is None:
+            raise ValueError("query request requires question")
+
+        payload = {
+            "skill": "query",
+            "question": question,
+        }
+        image = request.get("image")
+        if image is not None:
+            payload["image_url"] = _encode_image(image).image_url
+        spatial_refs = request.get("spatial_refs")
+        if spatial_refs is not None:
+            payload["spatial_refs"] = spatial_refs
+        reasoning = request.get("reasoning")
+        if reasoning is not None:
+            payload["reasoning"] = reasoning
+        settings = self._validate_rollout_settings("query", request.get("settings"))
+        if settings is not None:
+            payload["settings"] = settings
+        return payload
+
+    def _serialize_point_request(self, request: PointFinetuneRequest) -> dict:
+        object_name = request.get("object")
+        image = request.get("image")
+        if object_name is None:
+            raise ValueError("point request requires object")
+        if image is None:
+            raise ValueError("point request requires image")
+
+        payload = {
+            "skill": "point",
+            "object": object_name,
+            "image_url": _encode_image(image).image_url,
+        }
+        settings = self._validate_rollout_settings("point", request.get("settings"))
+        if settings is not None:
+            payload["settings"] = settings
+        return payload
+
+    def _serialize_detect_request(self, request: DetectFinetuneRequest) -> dict:
+        object_name = request.get("object")
+        image = request.get("image")
+        if object_name is None:
+            raise ValueError("detect request requires object")
+        if image is None:
+            raise ValueError("detect request requires image")
+
+        payload = {
+            "skill": "detect",
+            "object": object_name,
+            "image_url": _encode_image(image).image_url,
+        }
+        settings = self._validate_rollout_settings("detect", request.get("settings"))
+        if settings is not None:
+            payload["settings"] = settings
+        return payload
+
+    def _serialize_ground_truth(
+        self, skill: str, ground_truth: Optional[FinetuneGroundTruth]
+    ) -> Optional[dict]:
+        if ground_truth is None:
+            return None
+        if skill == "query":
+            raise ValueError("query rollouts do not support ground_truth")
+        if skill == "point":
+            return self._serialize_point_ground_truth(ground_truth)  # type: ignore[arg-type]
+        if skill == "detect":
+            return self._serialize_detect_ground_truth(ground_truth)  # type: ignore[arg-type]
+        raise ValueError(f"unsupported skill: {skill}")
+
+    def _serialize_point_ground_truth(self, ground_truth: PointGroundTruth) -> dict:
+        has_points = "points" in ground_truth
+        has_boxes = "boxes" in ground_truth
+        if has_points == has_boxes:
+            raise ValueError("point ground_truth requires exactly one of points or boxes")
+        if has_points:
+            return {"points": ground_truth["points"]}
+        return {"boxes": ground_truth["boxes"]}
+
+    def _serialize_detect_ground_truth(self, ground_truth: DetectGroundTruth) -> dict:
+        if "boxes" not in ground_truth:
+            raise ValueError("detect ground_truth requires boxes")
+        return {"boxes": ground_truth["boxes"]}
+
+    def _serialize_targets(self, request_payload: dict, targets: Sequence[dict]) -> List[dict]:
+        skill = request_payload["skill"]
+        if not targets:
+            raise ValueError("SFTGroup requires at least one target")
+        if skill == "query":
+            return [self._serialize_query_target(request_payload, target) for target in targets]
+        if skill == "point":
+            return [self._serialize_point_target(target) for target in targets]
+        if skill == "detect":
+            return [self._serialize_detect_target(target) for target in targets]
+        raise ValueError(f"unsupported skill: {skill}")
+
+    def _serialize_query_target(self, request_payload: dict, target: QueryTarget) -> dict:
+        answer = target.get("answer")
+        if answer is None:
+            raise ValueError("query SFT targets require answer")
+        payload = {"answer": answer}
+        if request_payload.get("reasoning"):
+            reasoning = target.get("reasoning")
+            if reasoning is None:
+                raise ValueError("query SFT targets require reasoning when request.reasoning is true")
+            payload["reasoning"] = reasoning
+        elif "reasoning" in target:
+            raise ValueError("query SFT targets should omit reasoning when request.reasoning is false")
+        return payload
+
+    def _serialize_point_target(self, target: PointTarget) -> dict:
+        has_points = "points" in target
+        has_boxes = "boxes" in target
+        if has_points == has_boxes:
+            raise ValueError("point SFT targets require exactly one of points or boxes")
+        if has_points:
+            return {"points": target["points"]}
+        return {"boxes": target["boxes"]}
+
+    def _serialize_detect_target(self, target: DetectTarget) -> dict:
+        if "boxes" not in target:
+            raise ValueError("detect SFT targets require boxes")
+        return {"boxes": target["boxes"]}
+
+    def delete(self) -> None:
+        self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
+
+    def rollouts(
+        self,
+        request: FinetuneRequest,
+        num_rollouts: int = 1,
+        ground_truth: Optional[FinetuneGroundTruth] = None,
+    ) -> RLGroup:
+        if num_rollouts < 1 or num_rollouts > 16:
+            raise ValueError("num_rollouts must be between 1 and 16")
+
+        request_payload = self._serialize_request(request)
+        payload = {
+            "finetune_id": self.finetune_id,
+            "num_rollouts": num_rollouts,
+            "request": request_payload,
+        }
+        ground_truth_payload = self._serialize_ground_truth(
+            request_payload["skill"], ground_truth
+        )
+        if ground_truth_payload is not None:
+            payload["ground_truth"] = ground_truth_payload
+
+        result = self._request_json("POST", "/rollouts", payload=payload)
+        return RLGroup(
+            request=request,
+            rollouts=result["rollouts"],
+            rewards=result.get("rewards"),
+            _request_payload=result.get("request", request_payload),
+        )
+
+    async def _rollouts_async(self, spec: RolloutSpec) -> RLGroup:
+        if spec.num_rollouts < 1 or spec.num_rollouts > 16:
+            raise ValueError("num_rollouts must be between 1 and 16")
+
+        request_payload = self._serialize_request(spec.request)
+        payload = {
+            "finetune_id": self.finetune_id,
+            "num_rollouts": spec.num_rollouts,
+            "request": request_payload,
+        }
+        ground_truth_payload = self._serialize_ground_truth(
+            request_payload["skill"], spec.ground_truth
+        )
+        if ground_truth_payload is not None:
+            payload["ground_truth"] = ground_truth_payload
+
+        result = await self._request_json_async("POST", "/rollouts", payload=payload)
+        return RLGroup(
+            request=spec.request,
+            rollouts=result["rollouts"],
+            rewards=result.get("rewards"),
+            _request_payload=result.get("request", request_payload),
+        )
+
+    def rollout_groups(
+        self,
+        specs: Sequence[RolloutSpec],
+        max_concurrency: int = 4,
+    ) -> List[RLGroup]:
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be at least 1")
+        specs_list = list(specs)
+        if not specs_list:
+            return []
+        return self._run_async(
+            self._rollout_groups_async(specs_list, max_concurrency=max_concurrency)
+        )
+
+    async def _rollout_groups_async(
+        self,
+        specs: Sequence[RolloutSpec],
+        max_concurrency: int,
+    ) -> List[RLGroup]:
+        results: List[Optional[RLGroup]] = [None] * len(specs)
+        next_index = 0
+        first_error: Optional[BaseException] = None
+        lock = asyncio.Lock()
+        stop = asyncio.Event()
+
+        async def worker():
+            nonlocal next_index, first_error
+
+            while True:
+                async with lock:
+                    if stop.is_set() or next_index >= len(specs):
+                        return
+                    index = next_index
+                    next_index += 1
+
+                try:
+                    results[index] = await self._rollouts_async(specs[index])
+                except Exception as exc:
+                    if not stop.is_set():
+                        first_error = exc
+                        stop.set()
+                    return
+
+        tasks = [
+            asyncio.create_task(worker())
+            for _ in range(min(max_concurrency, len(specs)))
+        ]
+        await asyncio.gather(*tasks)
+
+        if first_error is not None:
+            raise first_error
+
+        return [result for result in results if result is not None]
+
+    def train_step(
+        self,
+        groups: Sequence[object],
+        lr: float = 0.002,
+    ) -> TrainStepOutput:
+        if not groups:
+            raise ValueError("train_step requires at least one group")
+
+        payload_groups = []
+        for group in groups:
+            if isinstance(group, RLGroup):
+                if group.rewards is None:
+                    raise ValueError("RLGroup rewards must be set before train_step")
+                request_payload = group._request_payload
+                if request_payload is None:
+                    request_payload = self._serialize_request(group.request)
+                payload_groups.append(
+                    {
+                        "mode": "rl",
+                        "request": request_payload,
+                        "rollouts": group.rollouts,
+                        "rewards": group.rewards,
+                    }
+                )
+                continue
+
+            if isinstance(group, SFTGroup):
+                request_payload = self._serialize_request(group.request)
+                payload_groups.append(
+                    {
+                        "mode": "sft",
+                        "request": request_payload,
+                        "targets": self._serialize_targets(
+                            request_payload, group.targets
+                        ),
+                    }
+                )
+                continue
+
+            raise ValueError("train_step groups must be RLGroup or SFTGroup")
+
+        payload = {
+            "finetune_id": self.finetune_id,
+            "groups": payload_groups,
+            "lr": lr,
+        }
+        result = self._request_json("POST", "/train_step", payload=payload)
+        return {key: result[key] for key in _TRAIN_STEP_OUTPUT_KEYS if key in result}
+
+    def list_checkpoints(
+        self,
+        limit: int = 50,
+        cursor: Optional[str] = None,
+    ) -> CheckpointListOutput:
+        if limit < 1 or limit > 100:
+            raise ValueError("limit must be between 1 and 100")
+        return self._request_json(
+            "GET",
+            f"/finetunes/{self.finetune_id}/checkpoints",
+            query={"limit": limit, "cursor": cursor},
+        )
+
+    def save_checkpoint(self) -> CheckpointInfo:
+        result = self._request_json(
+            "POST", f"/finetunes/{self.finetune_id}/checkpoints/save"
+        )
+        return result["checkpoint"]
+
+    def delete_checkpoint(self, step: int) -> None:
+        self._request_json(
+            "DELETE", f"/finetunes/{self.finetune_id}/checkpoints/{step}"
+        )
+
+    def download_checkpoint(self, step: int) -> CheckpointDownload:
+        return self._request_json(
+            "GET", f"/finetunes/{self.finetune_id}/checkpoints/{step}/download"
+        )
+
+    def model(self, step: int) -> str:
+        if step < 0:
+            raise ValueError("step must be non-negative")
+        return f"moondream3-preview/{self.finetune_id}@{step}"
+
+    def _run_async(self, coro):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+
+        result = {}
+
+        def runner():
+            try:
+                result["value"] = asyncio.run(coro)
+            except BaseException as exc:
+                result["error"] = exc
+
+        thread = threading.Thread(target=runner)
+        thread.start()
+        thread.join()
+        if "error" in result:
+            raise result["error"]
+        return result["value"]
+
+
+def _validate_name(name: str):
+    if not _NAME_PATTERN.fullmatch(name):
+        raise ValueError("name must use only alphanumeric characters, hyphens, or underscores")
+
+
+def _validate_rank(rank: int):
+    if rank not in {8, 16, 24, 32}:
+        raise ValueError("rank must be one of 8, 16, 24, or 32")
+
+
+def ft(
+    api_key: Optional[str] = None,
+    *,
+    name: Optional[str] = None,
+    rank: Optional[int] = None,
+    finetune_id: Optional[str] = None,
+    endpoint: str = DEFAULT_TUNING_ENDPOINT,
+    max_retries: int = 5,
+    retry_base_delay: float = 0.5,
+    retry_max_delay: float = 8.0,
+    timeout: float = 60.0,
+) -> Finetune:
+    if finetune_id is not None:
+        if name is not None or rank is not None:
+            raise ValueError("finetune_id cannot be combined with name or rank")
+        client = Finetune(
+            api_key=api_key,
+            endpoint=endpoint,
+            finetune_id=finetune_id,
+            name="",
+            rank=0,
+            max_retries=max_retries,
+            retry_base_delay=retry_base_delay,
+            retry_max_delay=retry_max_delay,
+            timeout=timeout,
+        )
+        result = client._request_json("GET", f"/finetunes/{finetune_id}")
+        finetune: FinetuneInfo = result.get("finetune", result)
+        client.finetune_id = finetune["finetune_id"]
+        client.name = finetune["name"]
+        client.rank = finetune["rank"]
+        return client
+
+    if name is None or rank is None:
+        raise ValueError("ft requires either finetune_id or both name and rank")
+
+    _validate_name(name)
+    _validate_rank(rank)
+
+    client = Finetune(
+        api_key=api_key,
+        endpoint=endpoint,
+        finetune_id="",
+        name=name,
+        rank=rank,
+        max_retries=max_retries,
+        retry_base_delay=retry_base_delay,
+        retry_max_delay=retry_max_delay,
+        timeout=timeout,
+    )
+    result = client._request_json(
+        "POST",
+        "/finetunes",
+        payload={"name": name, "rank": rank},
+    )
+    client.finetune_id = result["finetune_id"]
+    client.name = name
+    client.rank = rank
+    return client

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -653,8 +653,6 @@ class Finetune:
             if isinstance(group, RLGroup):
                 if group.rewards is None:
                     raise ValueError("RLGroup rewards must be set before train_step")
-                if len(group.rewards) != len(group.rollouts):
-                    raise ValueError("rewards must match rollouts length")
                 request_payload = group._request_payload
                 if request_payload is None:
                     request_payload = self._serialize_group_request(group)
@@ -663,6 +661,12 @@ class Finetune:
                     raise ValueError(
                         "RLGroup rollouts must come from ft.*_rollouts before train_step"
                     )
+                if len(group.rollouts) != len(rollouts_payload):
+                    raise ValueError(
+                        "RLGroup rollouts must not be mutated after ft.*_rollouts"
+                    )
+                if len(group.rewards) != len(rollouts_payload):
+                    raise ValueError("rewards must match rollouts length")
                 payload_groups.append(
                     {
                         "mode": "rl",

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -363,7 +363,7 @@ class Finetune:
             self._batch_rollouts_async(requests_list, max_concurrency=max_concurrency)
         )
 
-    def sft_group(
+    def build_sft_group(
         self,
         *,
         skill: Skill,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -333,28 +333,14 @@ class Finetune:
             "groups": list(groups),
             "lr": lr,
         }
-        result = self._request_json("POST", "/train_step", payload=payload)
-        return result
+        return self._request_json("POST", "/train_step", payload=payload)
 
     def log_metrics(
         self,
         step: int,
         metrics: Mapping[str, float],
     ) -> MetricsLogOutput:
-        """Log user-defined metrics for a training step.
-
-        Metric names must match `[A-Za-z0-9_/-]+`, cannot start with `sys/` or
-        `usr/`, and values must be finite numbers.
-
-        Example:
-            ft.log_metrics(
-                step=step_output["step"],
-                metrics={
-                    "eval/country_match": 0.63,
-                    "eval/token_f1": 0.64,
-                },
-            )
-        """
+        """Log user-defined metrics for a training step."""
         return self._request_json(
             "POST",
             f"/finetunes/{self.finetune_id}/metrics",

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -617,6 +617,8 @@ class Finetune:
             if isinstance(group, RLGroup):
                 if group.rewards is None:
                     raise ValueError("RLGroup rewards must be set before train_step")
+                if len(group.rewards) != len(group.rollouts):
+                    raise ValueError("rewards must match rollouts length")
                 request_payload = group._request_payload
                 if request_payload is None:
                     request_payload = self._serialize_group_request(group)

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -273,18 +273,6 @@ class Finetune:
 
         raise FinetuneAPIError(f"{path} failed: {last_error}")
 
-    def _validate_rollout_settings(
-        self, skill: str, settings: Optional[SamplingSettings]
-    ) -> Optional[dict]:
-        if settings is None:
-            return None
-        settings_dict = dict(settings)
-        if skill == "query" and "max_objects" in settings_dict:
-            raise ValueError("query settings do not accept max_objects")
-        if skill in ("point", "detect") and "max_tokens" in settings_dict:
-            raise ValueError(f"{skill} settings do not accept max_tokens")
-        return settings_dict or None
-
     def _serialize_request(
         self,
         skill: str,
@@ -310,7 +298,7 @@ class Finetune:
                 payload["spatial_refs"] = list(spatial_refs)
             if reasoning:
                 payload["reasoning"] = True
-            settings_payload = self._validate_rollout_settings("query", settings)
+            settings_payload = dict(settings) if settings is not None else None
             if settings_payload is not None:
                 payload["settings"] = settings_payload
             return payload
@@ -326,7 +314,7 @@ class Finetune:
                 "object": object,
                 "image_url": _encode_image(image).image_url,
             }
-            settings_payload = self._validate_rollout_settings("point", settings)
+            settings_payload = dict(settings) if settings is not None else None
             if settings_payload is not None:
                 payload["settings"] = settings_payload
             return payload
@@ -342,7 +330,7 @@ class Finetune:
                 "object": object,
                 "image_url": _encode_image(image).image_url,
             }
-            settings_payload = self._validate_rollout_settings("detect", settings)
+            settings_payload = dict(settings) if settings is not None else None
             if settings_payload is not None:
                 payload["settings"] = settings_payload
             return payload
@@ -482,6 +470,10 @@ class Finetune:
         reasoning: bool = False,
         spatial_refs: Optional[Sequence[SpatialRef]] = None,
     ) -> RLGroup:
+        """Generate query rollouts.
+
+        Query settings typically use `temperature`, `top_p`, and `max_tokens`.
+        """
         if question is None:
             raise ValueError("question parameter is required")
         return self._rollouts_from_group(
@@ -503,6 +495,10 @@ class Finetune:
         settings: Optional[SamplingSettings] = None,
         ground_truth: Optional[PointGroundTruth] = None,
     ) -> RLGroup:
+        """Generate point rollouts.
+
+        Point settings typically use `temperature`, `top_p`, and `max_objects`.
+        """
         return self._rollouts_from_group(
             RolloutGroup.point(
                 image=image,
@@ -521,6 +517,10 @@ class Finetune:
         settings: Optional[SamplingSettings] = None,
         ground_truth: Optional[DetectGroundTruth] = None,
     ) -> RLGroup:
+        """Generate detect rollouts.
+
+        Detect settings typically use `temperature`, `top_p`, and `max_objects`.
+        """
         return self._rollouts_from_group(
             RolloutGroup.detect(
                 image=image,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -16,14 +16,15 @@ from PIL import Image
 
 from .types import (
     Base64EncodedImage,
-    CheckpointInfo,
     CheckpointListOutput,
     FinetuneInfo,
     EncodedImage,
     MetricsLogOutput,
+    OkResponse,
     RLGroup,
     RolloutRequest,
     RolloutsResponse,
+    SaveCheckpointOutput,
     SFTTarget,
     Skill,
     SkillRequest,
@@ -331,8 +332,8 @@ class Finetune:
             payload=self._rollouts_payload(request),
         )
 
-    def delete(self) -> None:
-        self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
+    def delete(self) -> OkResponse:
+        return self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
 
     async def _rollouts_async(self, request: RolloutRequest) -> RolloutsResponse:
         return await self._request_json_async(
@@ -479,14 +480,13 @@ class Finetune:
             query={"limit": limit, "cursor": cursor},
         )
 
-    def save_checkpoint(self) -> CheckpointInfo:
-        result = self._request_json(
+    def save_checkpoint(self) -> SaveCheckpointOutput:
+        return self._request_json(
             "POST", f"/finetunes/{self.finetune_id}/checkpoints/save"
         )
-        return result["checkpoint"]
 
-    def delete_checkpoint(self, step: int) -> None:
-        self._request_json(
+    def delete_checkpoint(self, step: int) -> OkResponse:
+        return self._request_json(
             "DELETE", f"/finetunes/{self.finetune_id}/checkpoints/{step}"
         )
 

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -291,13 +291,13 @@ class Finetune:
                 yield item
         finally:
             stop.set()
-            while True:
-                try:
-                    result_queue.get_nowait()
-                except queue.Empty:
-                    break
             for t in threads:
-                t.join(timeout=5.0)
+                while t.is_alive():
+                    try:
+                        result_queue.get_nowait()
+                    except queue.Empty:
+                        pass
+                    t.join(timeout=0.1)
 
     def build_sft_group(
         self,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -303,7 +303,7 @@ class Finetune:
         self,
         *,
         skill: Skill,
-        targets: Sequence[SFTTarget],
+        target: SFTTarget,
         image: Optional[Union[Image.Image, EncodedImage]] = None,
         question: Optional[str] = None,
         object: Optional[str] = None,
@@ -320,7 +320,7 @@ class Finetune:
                 spatial_refs=spatial_refs,
                 reasoning=reasoning,
             ),
-            "targets": list(targets),
+            "target": target,
         }
 
     def train_step(

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -1,9 +1,7 @@
 import asyncio
 import base64
 import json
-import math
 import random
-import re
 import socket
 import threading
 import time
@@ -38,7 +36,6 @@ __version__ = _pkg_version("moondream")
 
 DEFAULT_TUNING_ENDPOINT = "https://api.moondream.ai/v1/tuning"
 
-_METRIC_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_/-]+$")
 _RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504, 524}
 _TRAIN_STEP_OUTPUT_KEYS = (
     "step",
@@ -433,33 +430,9 @@ class Finetune:
         groups: Sequence[Union[RLGroup, SFTGroup]],
         lr: float = 0.002,
     ) -> TrainStepOutput:
-        if not groups:
-            raise ValueError("train_step requires at least one group")
-
-        payload_groups = []
-        for group in groups:
-            mode = group.get("mode")
-            if mode == "rl":
-                rewards = group.get("rewards")
-                rollouts = group.get("rollouts")
-                if rewards is None:
-                    raise ValueError("RLGroup rewards must be set before train_step")
-                if rollouts is None:
-                    raise ValueError("RLGroup requires rollouts")
-                if len(rewards) != len(rollouts):
-                    raise ValueError("rewards must match rollouts length")
-                payload_groups.append(group)
-                continue
-
-            if mode == "sft":
-                payload_groups.append(group)
-                continue
-
-            raise ValueError("train_step groups must have mode 'rl' or 'sft'")
-
         payload = {
             "finetune_id": self.finetune_id,
-            "groups": payload_groups,
+            "groups": list(groups),
             "lr": lr,
         }
         result = self._request_json(
@@ -489,34 +462,10 @@ class Finetune:
                 },
             )
         """
-        if isinstance(step, bool) or not isinstance(step, int) or step < 0:
-            raise ValueError("step must be a non-negative integer")
-
-        metrics_dict = dict(metrics)
-        if not metrics_dict:
-            raise ValueError("metrics must include at least one entry")
-        if len(metrics_dict) > 100:
-            raise ValueError("metrics cannot include more than 100 entries")
-
-        payload_metrics = {}
-        for name, value in metrics_dict.items():
-            if not _METRIC_NAME_PATTERN.fullmatch(name):
-                raise ValueError(
-                    "metric names must use only letters, numbers, underscores, slashes, or hyphens"
-                )
-            if name.startswith("sys/") or name.startswith("usr/"):
-                raise ValueError("metric names cannot start with sys/ or usr/")
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise ValueError("metric values must be finite numbers")
-            metric_value = float(value)
-            if not math.isfinite(metric_value):
-                raise ValueError("metric values must be finite numbers")
-            payload_metrics[name] = metric_value
-
         return self._request_json(
             "POST",
             f"/finetunes/{self.finetune_id}/metrics",
-            payload={"step": step, "metrics": payload_metrics},
+            payload={"step": step, "metrics": dict(metrics)},
         )
 
     def list_checkpoints(
@@ -524,8 +473,6 @@ class Finetune:
         limit: int = 50,
         cursor: Optional[str] = None,
     ) -> CheckpointListOutput:
-        if limit < 1 or limit > 100:
-            raise ValueError("limit must be between 1 and 100")
         return self._request_json(
             "GET",
             f"/finetunes/{self.finetune_id}/checkpoints",
@@ -544,8 +491,6 @@ class Finetune:
         )
 
     def model(self, step: int) -> str:
-        if step < 0:
-            raise ValueError("step must be non-negative")
         return f"moondream3-preview/{self.finetune_id}@{step}"
 
     def _run_async(self, coro):

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -805,11 +805,6 @@ def _validate_name(name: str):
         raise ValueError("name must use only alphanumeric characters, hyphens, or underscores")
 
 
-def _validate_rank(rank: int):
-    if rank not in {8, 16, 24, 32}:
-        raise ValueError("rank must be one of 8, 16, 24, or 32")
-
-
 def ft(
     api_key: Optional[str] = None,
     *,
@@ -847,7 +842,6 @@ def ft(
         raise ValueError("ft requires either finetune_id or both name and rank")
 
     _validate_name(name)
-    _validate_rank(rank)
 
     client = Finetune(
         api_key=api_key,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -1,6 +1,6 @@
-import asyncio
 import base64
 import json
+import queue
 import random
 import socket
 import threading
@@ -10,7 +10,7 @@ import urllib.parse
 import urllib.request
 from io import BytesIO
 from importlib.metadata import version as _pkg_version
-from typing import Dict, List, Mapping, Optional, Sequence, Union
+from typing import Dict, Generator, Iterable, List, Mapping, Optional, Sequence, Union
 
 from PIL import Image
 
@@ -226,35 +226,6 @@ class Finetune:
 
         raise FinetuneAPIError(f"{path} failed: {last_error}")
 
-    async def _request_json_async(
-        self,
-        method: str,
-        path: str,
-        payload: Optional[dict] = None,
-        query: Optional[dict] = None,
-    ) -> dict:
-        last_error: Optional[Exception] = None
-        for attempt in range(self.max_retries + 1):
-            try:
-                return await asyncio.to_thread(
-                    self._request_json_once,
-                    method,
-                    path,
-                    payload,
-                    query,
-                )
-            except Exception as exc:
-                last_error = exc
-                if not _is_retryable_error(exc) or attempt == self.max_retries:
-                    if isinstance(exc, urllib.error.HTTPError):
-                        _raise_http_error(path, exc)
-                    raise FinetuneAPIError(f"{path} failed: {exc}") from exc
-                if isinstance(exc, urllib.error.HTTPError):
-                    _close_http_error(exc)
-                await asyncio.sleep(self._backoff_delay(attempt))
-
-        raise FinetuneAPIError(f"{path} failed: {last_error}")
-
     def _request_payload(
         self,
         *,
@@ -325,31 +296,103 @@ class Finetune:
     def delete(self) -> OkResponse:
         return self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
 
-    async def _rollouts_async(self, request: RolloutRequest) -> RolloutsResponse:
-        return await self._request_json_async(
-            "POST",
-            "/rollouts",
-            payload=self._rollouts_payload(request),
-        )
-
-    def batch_rollouts(
+    def rollout_stream(
         self,
-        requests: Sequence[RolloutRequest],
+        requests: Iterable[RolloutRequest],
+        *,
         max_concurrency: int = 4,
-    ) -> List[RLGroup]:
-        """Generate multiple rollout requests in parallel.
+        buffer_size: int = 8,
+    ) -> Generator[RolloutsResponse, None, None]:
+        """Generate rollouts in the background, yielding responses as they complete.
 
-        Returns RL groups with `mode`, `request`, and `rollouts` populated.
-        Fill `group["rewards"]` before calling `train_step(...)`.
+        Rollout requests are dispatched from background threads so that
+        the caller can run train_step while the next batch of rollouts is
+        already in flight.  The bounded buffer provides backpressure so
+        generation never gets too far ahead of training.
+
+        Results are yielded in completion order, not submission order.
         """
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be at least 1")
-        requests_list = list(requests)
-        if not requests_list:
-            return []
-        return self._run_async(
-            self._batch_rollouts_async(requests_list, max_concurrency=max_concurrency)
-        )
+        if buffer_size < 1:
+            raise ValueError("buffer_size must be at least 1")
+
+        result_queue: queue.Queue = queue.Queue(maxsize=buffer_size)
+        requests_iter = iter(requests)
+        requests_lock = threading.Lock()
+        stop = threading.Event()
+        remaining = [max_concurrency]
+        remaining_lock = threading.Lock()
+        _DONE = object()
+
+        def worker():
+            try:
+                while not stop.is_set():
+                    with requests_lock:
+                        try:
+                            request = next(requests_iter)
+                        except StopIteration:
+                            return
+                        except Exception as exc:
+                            stop.set()
+                            while True:
+                                try:
+                                    result_queue.put(exc, timeout=0.1)
+                                    break
+                                except queue.Full:
+                                    continue
+                            return
+
+                    if stop.is_set():
+                        return
+
+                    try:
+                        response = self.rollouts(request)
+                    except Exception as exc:
+                        stop.set()
+                        while True:
+                            try:
+                                result_queue.put(exc, timeout=0.1)
+                                break
+                            except queue.Full:
+                                continue
+                        return
+
+                    while not stop.is_set():
+                        try:
+                            result_queue.put(response, timeout=0.1)
+                            break
+                        except queue.Full:
+                            continue
+            finally:
+                with remaining_lock:
+                    remaining[0] -= 1
+                    if remaining[0] == 0:
+                        result_queue.put(_DONE)
+
+        threads = []
+        for _ in range(max_concurrency):
+            t = threading.Thread(target=worker, daemon=True)
+            t.start()
+            threads.append(t)
+
+        try:
+            while True:
+                item = result_queue.get()
+                if item is _DONE:
+                    return
+                if isinstance(item, Exception):
+                    raise item
+                yield item
+        finally:
+            stop.set()
+            while True:
+                try:
+                    result_queue.get_nowait()
+                except queue.Empty:
+                    break
+            for t in threads:
+                t.join(timeout=5.0)
 
     def build_sft_group(
         self,
@@ -374,47 +417,6 @@ class Finetune:
             ),
             "targets": list(targets),
         }
-
-    async def _batch_rollouts_async(
-        self,
-        requests: Sequence[RolloutRequest],
-        max_concurrency: int,
-    ) -> List[RLGroup]:
-        results: List[Optional[RLGroup]] = [None] * len(requests)
-        next_index = 0
-        first_error: Optional[BaseException] = None
-        lock = asyncio.Lock()
-        stop = asyncio.Event()
-
-        async def worker():
-            nonlocal next_index, first_error
-
-            while True:
-                async with lock:
-                    if stop.is_set() or next_index >= len(requests):
-                        return
-                    index = next_index
-                    next_index += 1
-
-                try:
-                    response = await self._rollouts_async(requests[index])
-                    results[index] = self._rl_group_from_response(response)
-                except Exception as exc:
-                    if not stop.is_set():
-                        first_error = exc
-                        stop.set()
-                    return
-
-        tasks = [
-            asyncio.create_task(worker())
-            for _ in range(min(max_concurrency, len(requests)))
-        ]
-        await asyncio.gather(*tasks)
-
-        if first_error is not None:
-            raise first_error
-
-        return [result for result in results if result is not None]
 
     def train_step(
         self,
@@ -482,27 +484,6 @@ class Finetune:
 
     def model(self, step: int) -> str:
         return f"moondream3-preview/{self.finetune_id}@{step}"
-
-    def _run_async(self, coro):
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(coro)
-
-        result = {}
-
-        def runner():
-            try:
-                result["value"] = asyncio.run(coro)
-            except BaseException as exc:
-                result["error"] = exc
-
-        thread = threading.Thread(target=runner)
-        thread.start()
-        thread.join()
-        if "error" in result:
-            raise result["error"]
-        return result["value"]
 
 
 def ft(

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import copy
 import json
 import math
 import random
@@ -447,7 +448,7 @@ class Finetune:
         rollouts_payload = result.get("rollouts", [])
         return RLGroup(
             skill=group.skill,
-            rollouts=[dict(rollout.get("output", {})) for rollout in rollouts_payload],
+            rollouts=[copy.deepcopy(rollout.get("output", {})) for rollout in rollouts_payload],
             image=group.image,
             question=group.question,
             object=group.object,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -41,19 +41,6 @@ DEFAULT_TUNING_ENDPOINT = "https://api.moondream.ai/v1/tuning"
 _RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504, 524}
 
 
-class FinetuneAPIError(RuntimeError):
-    def __init__(
-        self,
-        message: str,
-        *,
-        status: Optional[int] = None,
-        body: Optional[object] = None,
-    ):
-        super().__init__(message)
-        self.status = status
-        self.body = body
-
-
 def _encode_image(image) -> Base64EncodedImage:
     if isinstance(image, Base64EncodedImage):
         return image
@@ -70,54 +57,12 @@ def _encode_image(image) -> Base64EncodedImage:
         raise ValueError("Failed to convert image to JPEG.") from exc
 
 
-def _error_message(exc: urllib.error.HTTPError) -> str:
-    body = ""
-    try:
-        body = exc.read().decode("utf-8")
-    except Exception:
-        body = ""
-
-    if body:
-        try:
-            parsed = json.loads(body)
-        except json.JSONDecodeError:
-            parsed = None
-        if isinstance(parsed, dict):
-            for key in ("error", "message", "detail"):
-                value = parsed.get(key)
-                if isinstance(value, str) and value:
-                    return value
-        if body.strip():
-            return body.strip()
-
-    return exc.reason if isinstance(exc.reason, str) else str(exc.reason)
-
-
-def _is_retryable_error(exc: Exception) -> bool:
+def _is_retryable(exc: Exception) -> bool:
     if isinstance(exc, urllib.error.HTTPError):
         return exc.code in _RETRY_STATUS_CODES
     if isinstance(exc, urllib.error.URLError):
         return True
     return isinstance(exc, (TimeoutError, socket.timeout))
-
-
-def _close_http_error(exc: urllib.error.HTTPError):
-    try:
-        exc.close()
-    except Exception:
-        pass
-
-
-def _raise_http_error(path: str, exc: urllib.error.HTTPError):
-    try:
-        message = _error_message(exc)
-    finally:
-        _close_http_error(exc)
-    raise FinetuneAPIError(
-        f"{path} failed with status {exc.code}: {message}",
-        status=exc.code,
-        body=message,
-    ) from exc
 
 
 class Finetune:
@@ -204,22 +149,17 @@ class Finetune:
         query: Optional[dict] = None,
         max_retries: Optional[int] = None,
     ) -> dict:
-        last_error: Optional[Exception] = None
         retries = self.max_retries if max_retries is None else max_retries
+        last_exc: Optional[Exception] = None
         for attempt in range(retries + 1):
             try:
                 return self._request_json_once(method, path, payload=payload, query=query)
             except Exception as exc:
-                last_error = exc
-                if not _is_retryable_error(exc) or attempt == retries:
-                    if isinstance(exc, urllib.error.HTTPError):
-                        _raise_http_error(path, exc)
-                    raise FinetuneAPIError(f"{path} failed: {exc}") from exc
-                if isinstance(exc, urllib.error.HTTPError):
-                    _close_http_error(exc)
+                last_exc = exc
+                if not _is_retryable(exc) or attempt == retries:
+                    raise
                 time.sleep(self._backoff_delay(attempt))
-
-        raise FinetuneAPIError(f"{path} failed: {last_error}")
+        raise last_exc  # unreachable, but keeps the type checker happy
 
     def _request_payload(
         self,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -142,8 +142,18 @@ def _is_retryable_error(exc: Exception) -> bool:
     return isinstance(exc, (TimeoutError, socket.timeout))
 
 
+def _close_http_error(exc: urllib.error.HTTPError):
+    try:
+        exc.close()
+    except Exception:
+        pass
+
+
 def _raise_http_error(path: str, exc: urllib.error.HTTPError):
-    message = _error_message(exc)
+    try:
+        message = _error_message(exc)
+    finally:
+        _close_http_error(exc)
     raise FinetuneAPIError(
         f"{path} failed with status {exc.code}: {message}",
         status=exc.code,
@@ -248,6 +258,8 @@ class Finetune:
                     if isinstance(exc, urllib.error.HTTPError):
                         _raise_http_error(path, exc)
                     raise FinetuneAPIError(f"{path} failed: {exc}") from exc
+                if isinstance(exc, urllib.error.HTTPError):
+                    _close_http_error(exc)
                 time.sleep(self._backoff_delay(attempt, exc))
 
         raise FinetuneAPIError(f"{path} failed: {last_error}")
@@ -275,6 +287,8 @@ class Finetune:
                     if isinstance(exc, urllib.error.HTTPError):
                         _raise_http_error(path, exc)
                     raise FinetuneAPIError(f"{path} failed: {exc}") from exc
+                if isinstance(exc, urllib.error.HTTPError):
+                    _close_http_error(exc)
                 await asyncio.sleep(self._backoff_delay(attempt, exc))
 
         raise FinetuneAPIError(f"{path} failed: {last_error}")

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -38,16 +38,6 @@ __version__ = _pkg_version("moondream")
 DEFAULT_TUNING_ENDPOINT = "https://api.moondream.ai/v1/tuning"
 
 _RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504, 524}
-_TRAIN_STEP_OUTPUT_KEYS = (
-    "step",
-    "applied",
-    "kl",
-    "router_kl",
-    "grad_norm",
-    "sft_loss",
-    "reward_mean",
-    "reward_std",
-)
 
 
 class FinetuneAPIError(RuntimeError):
@@ -442,7 +432,7 @@ class Finetune:
             payload=payload,
             max_retries=0,
         )
-        return {key: result[key] for key in _TRAIN_STEP_OUTPUT_KEYS if key in result}
+        return result
 
     def log_metrics(
         self,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -17,7 +17,6 @@ from PIL import Image
 
 from .types import (
     Base64EncodedImage,
-    CheckpointDownload,
     CheckpointInfo,
     CheckpointListOutput,
     DetectGroundTruth,
@@ -473,6 +472,11 @@ class Finetune:
         """Generate query rollouts.
 
         Query settings typically use `temperature`, `top_p`, and `max_tokens`.
+
+        Returns:
+            RLGroup: `group.rollouts` is a list of query output dicts such as
+            `{"answer": "People are smiling for a photo."}`. When `reasoning=True`,
+            each rollout may also include `{"reasoning": ...}`.
         """
         if question is None:
             raise ValueError("question parameter is required")
@@ -498,6 +502,10 @@ class Finetune:
         """Generate point rollouts.
 
         Point settings typically use `temperature`, `top_p`, and `max_objects`.
+
+        Returns:
+            RLGroup: `group.rollouts` is a list of point output dicts such as
+            `{"points": [{"x": 0.24, "y": 0.58}, {"x": 0.71, "y": 0.61}]}`.
         """
         return self._rollouts_from_group(
             RolloutGroup.point(
@@ -520,6 +528,10 @@ class Finetune:
         """Generate detect rollouts.
 
         Detect settings typically use `temperature`, `top_p`, and `max_objects`.
+
+        Returns:
+            RLGroup: `group.rollouts` is a list of detect output dicts such as
+            `{"objects": [{"x_min": 0.12, "y_min": 0.08, "x_max": 0.41, "y_max": 0.95}]}`.
         """
         return self._rollouts_from_group(
             RolloutGroup.detect(
@@ -682,11 +694,6 @@ class Finetune:
     def delete_checkpoint(self, step: int) -> None:
         self._request_json(
             "DELETE", f"/finetunes/{self.finetune_id}/checkpoints/{step}"
-        )
-
-    def download_checkpoint(self, step: int) -> CheckpointDownload:
-        return self._request_json(
-            "GET", f"/finetunes/{self.finetune_id}/checkpoints/{step}/download"
         )
 
     def model(self, step: int) -> str:

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -26,8 +26,11 @@ from .types import (
     RLGroup,
     RolloutRequest,
     RolloutsResponse,
+    SFTTarget,
+    Skill,
     SkillRequest,
     SFTGroup,
+    SpatialRef,
     TrainStepOutput,
 )
 
@@ -264,27 +267,45 @@ class Finetune:
 
         raise FinetuneAPIError(f"{path} failed: {last_error}")
 
-    def _request_payload(self, request: RolloutRequest) -> SkillRequest:
-        payload: SkillRequest = {"skill": request.skill}
-        if request.image is not None:
-            payload["image_url"] = _encode_image(request.image).image_url
-        if request.question is not None:
-            payload["question"] = request.question
-        if request.object is not None:
-            payload["object"] = request.object
-        if request.spatial_refs is not None:
-            payload["spatial_refs"] = list(request.spatial_refs)
-        if request.reasoning:
+    def _request_payload(
+        self,
+        *,
+        skill: Skill,
+        image: Optional[Union[Image.Image, EncodedImage]] = None,
+        question: Optional[str] = None,
+        object: Optional[str] = None,
+        spatial_refs: Optional[Sequence[SpatialRef]] = None,
+        reasoning: bool = False,
+        settings: Optional[Mapping[str, object]] = None,
+    ) -> SkillRequest:
+        payload: SkillRequest = {"skill": skill}
+        if image is not None:
+            payload["image_url"] = _encode_image(image).image_url
+        if question is not None:
+            payload["question"] = question
+        if object is not None:
+            payload["object"] = object
+        if spatial_refs is not None:
+            payload["spatial_refs"] = list(spatial_refs)
+        if reasoning:
             payload["reasoning"] = True
-        if request.settings is not None:
-            payload["settings"] = dict(request.settings)
+        if settings is not None:
+            payload["settings"] = dict(settings)
         return payload
 
     def _rollouts_payload(self, request: RolloutRequest) -> dict:
         payload = {
             "finetune_id": self.finetune_id,
             "num_rollouts": request.num_rollouts,
-            "request": self._request_payload(request),
+            "request": self._request_payload(
+                skill=request.skill,
+                image=request.image,
+                question=request.question,
+                object=request.object,
+                spatial_refs=request.spatial_refs,
+                reasoning=request.reasoning,
+                settings=request.settings,
+            ),
         }
         if request.ground_truth is not None:
             payload["ground_truth"] = dict(request.ground_truth)
@@ -341,6 +362,30 @@ class Finetune:
         return self._run_async(
             self._batch_rollouts_async(requests_list, max_concurrency=max_concurrency)
         )
+
+    def sft_group(
+        self,
+        *,
+        skill: Skill,
+        targets: Sequence[SFTTarget],
+        image: Optional[Union[Image.Image, EncodedImage]] = None,
+        question: Optional[str] = None,
+        object: Optional[str] = None,
+        reasoning: bool = False,
+        spatial_refs: Optional[Sequence[SpatialRef]] = None,
+    ) -> SFTGroup:
+        return {
+            "mode": "sft",
+            "request": self._request_payload(
+                skill=skill,
+                image=image,
+                question=question,
+                object=object,
+                spatial_refs=spatial_refs,
+                reasoning=reasoning,
+            ),
+            "targets": list(targets),
+        }
 
     async def _batch_rollouts_async(
         self,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import math
 import random
 import re
 import socket
@@ -11,7 +12,7 @@ import urllib.parse
 import urllib.request
 from io import BytesIO
 from importlib.metadata import version as _pkg_version
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Dict, List, Mapping, Optional, Sequence, Union, cast
 
 from PIL import Image
 
@@ -20,15 +21,20 @@ from .types import (
     CheckpointInfo,
     CheckpointListOutput,
     DetectGroundTruth,
+    DetectOutput,
     DetectTarget,
     FinetuneGroundTruth,
     FinetuneInfo,
     EncodedImage,
+    MetricsLogOutput,
+    PointOutput,
     PointGroundTruth,
     PointTarget,
+    QueryOutput,
     QueryTarget,
     RLGroup,
     RolloutGroup,
+    RolloutOutput,
     SamplingSettings,
     SFTGroup,
     SpatialRef,
@@ -40,6 +46,7 @@ __version__ = _pkg_version("moondream")
 DEFAULT_TUNING_ENDPOINT = "https://api.moondream.ai/v1/tuning"
 
 _NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_METRIC_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_/-]+$")
 _RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504, 524}
 _TRAIN_STEP_OUTPUT_KEYS = (
     "step",
@@ -405,7 +412,7 @@ class Finetune:
 
     def _serialize_group_request(
         self,
-        group: Union[RolloutGroup, RLGroup, SFTGroup],
+        group: Union[RolloutGroup, RLGroup[RolloutOutput], SFTGroup],
     ) -> dict:
         return self._serialize_request(
             group.skill,
@@ -422,7 +429,7 @@ class Finetune:
         group: RolloutGroup,
         request_payload: dict,
         result: dict,
-    ) -> RLGroup:
+    ) -> RLGroup[RolloutOutput]:
         rollouts_payload = result.get("rollouts", [])
         return RLGroup(
             skill=group.skill,
@@ -438,7 +445,7 @@ class Finetune:
             _rollouts_payload=rollouts_payload,
         )
 
-    def _rollouts_from_group(self, group: RolloutGroup) -> RLGroup:
+    def _rollouts_from_group(self, group: RolloutGroup) -> RLGroup[RolloutOutput]:
         if group.num_rollouts < 1 or group.num_rollouts > 16:
             raise ValueError("num_rollouts must be between 1 and 16")
 
@@ -468,7 +475,7 @@ class Finetune:
         settings: Optional[SamplingSettings] = None,
         reasoning: bool = False,
         spatial_refs: Optional[Sequence[SpatialRef]] = None,
-    ) -> RLGroup:
+    ) -> RLGroup[QueryOutput]:
         """Generate query rollouts.
 
         Query settings typically use `temperature`, `top_p`, and `max_tokens`.
@@ -480,7 +487,7 @@ class Finetune:
         """
         if question is None:
             raise ValueError("question parameter is required")
-        return self._rollouts_from_group(
+        group = self._rollouts_from_group(
             RolloutGroup.query(
                 question=question,
                 image=image,
@@ -490,6 +497,7 @@ class Finetune:
                 spatial_refs=list(spatial_refs) if spatial_refs is not None else None,
             )
         )
+        return cast(RLGroup[QueryOutput], group)
 
     def point_rollouts(
         self,
@@ -498,7 +506,7 @@ class Finetune:
         num_rollouts: int = 1,
         settings: Optional[SamplingSettings] = None,
         ground_truth: Optional[PointGroundTruth] = None,
-    ) -> RLGroup:
+    ) -> RLGroup[PointOutput]:
         """Generate point rollouts.
 
         Point settings typically use `temperature`, `top_p`, and `max_objects`.
@@ -507,7 +515,7 @@ class Finetune:
             RLGroup: `group.rollouts` is a list of point output dicts such as
             `{"points": [{"x": 0.24, "y": 0.58}, {"x": 0.71, "y": 0.61}]}`.
         """
-        return self._rollouts_from_group(
+        group = self._rollouts_from_group(
             RolloutGroup.point(
                 image=image,
                 object=object,
@@ -516,6 +524,7 @@ class Finetune:
                 ground_truth=ground_truth,
             )
         )
+        return cast(RLGroup[PointOutput], group)
 
     def detect_rollouts(
         self,
@@ -524,7 +533,7 @@ class Finetune:
         num_rollouts: int = 1,
         settings: Optional[SamplingSettings] = None,
         ground_truth: Optional[DetectGroundTruth] = None,
-    ) -> RLGroup:
+    ) -> RLGroup[DetectOutput]:
         """Generate detect rollouts.
 
         Detect settings typically use `temperature`, `top_p`, and `max_objects`.
@@ -533,7 +542,7 @@ class Finetune:
             RLGroup: `group.rollouts` is a list of detect output dicts such as
             `{"objects": [{"x_min": 0.12, "y_min": 0.08, "x_max": 0.41, "y_max": 0.95}]}`.
         """
-        return self._rollouts_from_group(
+        group = self._rollouts_from_group(
             RolloutGroup.detect(
                 image=image,
                 object=object,
@@ -542,8 +551,9 @@ class Finetune:
                 ground_truth=ground_truth,
             )
         )
+        return cast(RLGroup[DetectOutput], group)
 
-    async def _rollouts_async(self, group: RolloutGroup) -> RLGroup:
+    async def _rollouts_async(self, group: RolloutGroup) -> RLGroup[RolloutOutput]:
         if group.num_rollouts < 1 or group.num_rollouts > 16:
             raise ValueError("num_rollouts must be between 1 and 16")
 
@@ -566,7 +576,7 @@ class Finetune:
         self,
         groups: Sequence[RolloutGroup],
         max_concurrency: int = 4,
-    ) -> List[RLGroup]:
+    ) -> List[RLGroup[RolloutOutput]]:
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be at least 1")
         groups_list = list(groups)
@@ -580,8 +590,8 @@ class Finetune:
         self,
         groups: Sequence[RolloutGroup],
         max_concurrency: int,
-    ) -> List[RLGroup]:
-        results: List[Optional[RLGroup]] = [None] * len(groups)
+    ) -> List[RLGroup[RolloutOutput]]:
+        results: List[Optional[RLGroup[RolloutOutput]]] = [None] * len(groups)
         next_index = 0
         first_error: Optional[BaseException] = None
         lock = asyncio.Lock()
@@ -618,7 +628,7 @@ class Finetune:
 
     def train_step(
         self,
-        groups: Sequence[Union[RLGroup, SFTGroup]],
+        groups: Sequence[Union[RLGroup[RolloutOutput], SFTGroup]],
         lr: float = 0.002,
     ) -> TrainStepOutput:
         if not groups:
@@ -671,6 +681,55 @@ class Finetune:
         }
         result = self._request_json("POST", "/train_step", payload=payload)
         return {key: result[key] for key in _TRAIN_STEP_OUTPUT_KEYS if key in result}
+
+    def log_metrics(
+        self,
+        step: int,
+        metrics: Mapping[str, float],
+    ) -> MetricsLogOutput:
+        """Log user-defined metrics for a training step.
+
+        Metric names must match `[A-Za-z0-9_/-]+`, cannot start with `sys/` or
+        `usr/`, and values must be finite numbers.
+
+        Example:
+            ft.log_metrics(
+                step=step_output["step"],
+                metrics={
+                    "eval/country_match": 0.63,
+                    "eval/token_f1": 0.64,
+                },
+            )
+        """
+        if isinstance(step, bool) or not isinstance(step, int) or step < 0:
+            raise ValueError("step must be a non-negative integer")
+
+        metrics_dict = dict(metrics)
+        if not metrics_dict:
+            raise ValueError("metrics must include at least one entry")
+        if len(metrics_dict) > 100:
+            raise ValueError("metrics cannot include more than 100 entries")
+
+        payload_metrics = {}
+        for name, value in metrics_dict.items():
+            if not _METRIC_NAME_PATTERN.fullmatch(name):
+                raise ValueError(
+                    "metric names must use only letters, numbers, underscores, slashes, or hyphens"
+                )
+            if name.startswith("sys/") or name.startswith("usr/"):
+                raise ValueError("metric names cannot start with sys/ or usr/")
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError("metric values must be finite numbers")
+            metric_value = float(value)
+            if not math.isfinite(metric_value):
+                raise ValueError("metric values must be finite numbers")
+            payload_metrics[name] = metric_value
+
+        return self._request_json(
+            "POST",
+            f"/finetunes/{self.finetune_id}/metrics",
+            payload={"step": step, "metrics": payload_metrics},
+        )
 
     def list_checkpoints(
         self,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -22,7 +22,6 @@ from .types import (
     EncodedImage,
     MetricsLogOutput,
     RLGroup,
-    RolloutRequest,
     RolloutsResponse,
     SamplingSettings,
     SaveCheckpointOutput,
@@ -187,25 +186,6 @@ class Finetune:
             payload["settings"] = dict(settings)
         return payload
 
-    def _rollouts_payload(self, request: RolloutRequest) -> dict:
-        payload = {
-            "finetune_id": self.finetune_id,
-            "num_rollouts": request.get("num_rollouts", 1),
-            "request": self._request_payload(
-                skill=request["skill"],
-                image=request.get("image"),
-                question=request.get("question"),
-                object=request.get("object"),
-                spatial_refs=request.get("spatial_refs"),
-                reasoning=request.get("reasoning", False),
-                settings=request.get("settings"),
-            ),
-        }
-        ground_truth = request.get("ground_truth")
-        if ground_truth is not None:
-            payload["ground_truth"] = dict(ground_truth)
-        return payload
-
     def rollouts(
         self,
         skill: Skill,
@@ -224,28 +204,22 @@ class Finetune:
         Returns the raw `/rollouts` response with `request`, `rollouts`, and
         optional `rewards`.
         """
-        request: RolloutRequest = {"skill": skill}
-        if image is not None:
-            request["image"] = image
-        if question is not None:
-            request["question"] = question
-        if object is not None:
-            request["object"] = object
-        if num_rollouts != 1:
-            request["num_rollouts"] = num_rollouts
-        if settings is not None:
-            request["settings"] = settings
-        if reasoning:
-            request["reasoning"] = reasoning
-        if spatial_refs is not None:
-            request["spatial_refs"] = list(spatial_refs)
+        payload: dict = {
+            "finetune_id": self.finetune_id,
+            "num_rollouts": num_rollouts,
+            "request": self._request_payload(
+                skill=skill,
+                image=image,
+                question=question,
+                object=object,
+                spatial_refs=spatial_refs,
+                reasoning=reasoning,
+                settings=settings,
+            ),
+        }
         if ground_truth is not None:
-            request["ground_truth"] = ground_truth
-        return self._request_json(
-            "POST",
-            "/rollouts",
-            payload=self._rollouts_payload(request),
-        )
+            payload["ground_truth"] = dict(ground_truth)
+        return self._request_json("POST", "/rollouts", payload=payload)
 
     def delete(self) -> None:
         self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
@@ -286,8 +260,10 @@ class Finetune:
 
         def worker():
             try:
-                while not stop.is_set():
+                while True:
                     with requests_lock:
+                        if stop.is_set():
+                            return
                         try:
                             context, request = next(requests_iter)
                         except StopIteration:
@@ -301,9 +277,6 @@ class Finetune:
                                 except queue.Full:
                                     continue
                             return
-
-                    if stop.is_set():
-                        return
 
                     try:
                         response = self.rollouts(**request)

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -414,7 +414,7 @@ class Finetune:
             object=group.object,
             spatial_refs=group.spatial_refs,
             reasoning=group.reasoning,
-            settings=group.settings,
+            settings=None if isinstance(group, SFTGroup) else group.settings,
         )
 
     def _rl_group_from_result(

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -25,7 +25,6 @@ from .types import (
     RolloutsResponse,
     SamplingSettings,
     SaveCheckpointOutput,
-    SFTTarget,
     Skill,
     SkillRequest,
     SFTGroup,
@@ -133,32 +132,6 @@ class Finetune:
                 time.sleep(random.uniform(0.0, max_delay))
         raise last_exc  # unreachable, but keeps the type checker happy
 
-    def _request_payload(
-        self,
-        *,
-        skill: Skill,
-        image: Optional[Union[Image.Image, EncodedImage]] = None,
-        question: Optional[str] = None,
-        object: Optional[str] = None,
-        spatial_refs: Optional[Sequence[SpatialRef]] = None,
-        reasoning: bool = False,
-        settings: Optional[Mapping[str, object]] = None,
-    ) -> SkillRequest:
-        payload: SkillRequest = {"skill": skill}
-        if image is not None:
-            payload["image_url"] = _encode_image(image).image_url
-        if question is not None:
-            payload["question"] = question
-        if object is not None:
-            payload["object"] = object
-        if spatial_refs is not None:
-            payload["spatial_refs"] = list(spatial_refs)
-        if reasoning:
-            payload["reasoning"] = True
-        if settings is not None:
-            payload["settings"] = dict(settings)
-        return payload
-
     def rollouts(
         self,
         skill: Skill,
@@ -177,18 +150,23 @@ class Finetune:
         Returns the raw `/rollouts` response with `request`, `rollouts`, and
         optional `rewards`.
         """
+        request: SkillRequest = {"skill": skill}
+        if image is not None:
+            request["image_url"] = _encode_image(image).image_url
+        if question is not None:
+            request["question"] = question
+        if object is not None:
+            request["object"] = object
+        if spatial_refs is not None:
+            request["spatial_refs"] = list(spatial_refs)
+        if reasoning:
+            request["reasoning"] = True
+        if settings is not None:
+            request["settings"] = dict(settings)
         payload: dict = {
             "finetune_id": self.finetune_id,
             "num_rollouts": num_rollouts,
-            "request": self._request_payload(
-                skill=skill,
-                image=image,
-                question=question,
-                object=object,
-                spatial_refs=spatial_refs,
-                reasoning=reasoning,
-                settings=settings,
-            ),
+            "request": request,
         }
         if ground_truth is not None:
             payload["ground_truth"] = dict(ground_truth)
@@ -299,38 +277,23 @@ class Finetune:
                         pass
                     t.join(timeout=0.1)
 
-    def build_sft_group(
-        self,
-        *,
-        skill: Skill,
-        target: SFTTarget,
-        image: Optional[Union[Image.Image, EncodedImage]] = None,
-        question: Optional[str] = None,
-        object: Optional[str] = None,
-        reasoning: bool = False,
-        spatial_refs: Optional[Sequence[SpatialRef]] = None,
-    ) -> SFTGroup:
-        return {
-            "mode": "sft",
-            "request": self._request_payload(
-                skill=skill,
-                image=image,
-                question=question,
-                object=object,
-                spatial_refs=spatial_refs,
-                reasoning=reasoning,
-            ),
-            "target": target,
-        }
-
     def train_step(
         self,
         groups: Sequence[Union[RLGroup, SFTGroup]],
         lr: float = 0.002,
     ) -> TrainStepOutput:
+        encoded_groups = []
+        for group in groups:
+            group = dict(group)
+            request = group.get("request")
+            if isinstance(request, dict) and "image" in request:
+                request = dict(request)
+                request["image_url"] = _encode_image(request.pop("image")).image_url
+                group["request"] = request
+            encoded_groups.append(group)
         payload = {
             "finetune_id": self.finetune_id,
-            "groups": list(groups),
+            "groups": encoded_groups,
             "lr": lr,
         }
         return self._request_json("POST", "/train_step", payload=payload)

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -20,7 +20,6 @@ from .types import (
     FinetuneInfo,
     EncodedImage,
     MetricsLogOutput,
-    OkResponse,
     RLGroup,
     RolloutRequest,
     RolloutsResponse,
@@ -293,17 +292,22 @@ class Finetune:
             payload=self._rollouts_payload(request),
         )
 
-    def delete(self) -> OkResponse:
-        return self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
+    def delete(self) -> None:
+        self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
 
     def rollout_stream(
         self,
-        requests: Iterable[RolloutRequest],
+        requests: Iterable[tuple],
         *,
         max_concurrency: int = 4,
         buffer_size: int = 8,
-    ) -> Generator[RolloutsResponse, None, None]:
-        """Generate rollouts in the background, yielding responses as they complete.
+    ) -> Generator[tuple, None, None]:
+        """Generate rollouts in the background, yielding results as they complete.
+
+        Takes an iterable of ``(context, RolloutRequest)`` tuples and yields
+        ``(context, RolloutsResponse)`` tuples.  The context is passed through
+        untouched so callers can pair responses with ground-truth labels or
+        other metadata needed for scoring.
 
         Rollout requests are dispatched from background threads so that
         the caller can run train_step while the next batch of rollouts is
@@ -330,7 +334,7 @@ class Finetune:
                 while not stop.is_set():
                     with requests_lock:
                         try:
-                            request = next(requests_iter)
+                            context, request = next(requests_iter)
                         except StopIteration:
                             return
                         except Exception as exc:
@@ -360,7 +364,7 @@ class Finetune:
 
                     while not stop.is_set():
                         try:
-                            result_queue.put(response, timeout=0.1)
+                            result_queue.put((context, response), timeout=0.1)
                             break
                         except queue.Full:
                             continue
@@ -477,8 +481,8 @@ class Finetune:
             "POST", f"/finetunes/{self.finetune_id}/checkpoints/save"
         )
 
-    def delete_checkpoint(self, step: int) -> OkResponse:
-        return self._request_json(
+    def delete_checkpoint(self, step: int) -> None:
+        self._request_json(
             "DELETE", f"/finetunes/{self.finetune_id}/checkpoints/{step}"
         )
 

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import copy
 import json
 import math
 import random
@@ -13,7 +12,7 @@ import urllib.parse
 import urllib.request
 from io import BytesIO
 from importlib.metadata import version as _pkg_version
-from typing import Dict, List, Mapping, Optional, Sequence, Union, cast
+from typing import Dict, List, Mapping, Optional, Sequence, Union
 
 from PIL import Image
 
@@ -21,24 +20,14 @@ from .types import (
     Base64EncodedImage,
     CheckpointInfo,
     CheckpointListOutput,
-    DetectGroundTruth,
-    DetectOutput,
-    DetectTarget,
-    FinetuneGroundTruth,
     FinetuneInfo,
     EncodedImage,
     MetricsLogOutput,
-    PointOutput,
-    PointGroundTruth,
-    PointTarget,
-    QueryOutput,
-    QueryTarget,
     RLGroup,
-    RolloutGroup,
-    RolloutOutput,
-    SamplingSettings,
+    RolloutRequest,
+    RolloutsResponse,
+    SkillRequest,
     SFTGroup,
-    SpatialRef,
     TrainStepOutput,
 )
 
@@ -46,7 +35,6 @@ __version__ = _pkg_version("moondream")
 
 DEFAULT_TUNING_ENDPOINT = "https://api.moondream.ai/v1/tuning"
 
-_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 _METRIC_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_/-]+$")
 _RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504, 524}
 _TRAIN_STEP_OUTPUT_KEYS = (
@@ -75,12 +63,6 @@ class FinetuneAPIError(RuntimeError):
 
 
 def _image_to_jpeg_bytes(image) -> bytes:
-    if isinstance(image, Base64EncodedImage):
-        data = image.image_url
-        if data.startswith("data:"):
-            data = data.split(",", 1)[1]
-        return base64.b64decode(data)
-
     if isinstance(image, Image.Image):
         try:
             if image.mode != "RGB":
@@ -100,16 +82,6 @@ def _encode_image(image) -> Base64EncodedImage:
     image_bytes = _image_to_jpeg_bytes(image)
     img_str = base64.b64encode(image_bytes).decode()
     return Base64EncodedImage(image_url=f"data:image/jpeg;base64,{img_str}")
-
-
-def _retry_after_seconds(headers) -> Optional[float]:
-    value = headers.get("Retry-After") if headers is not None else None
-    if value is None:
-        return None
-    try:
-        return max(0.0, float(value))
-    except ValueError:
-        return None
 
 
 def _error_message(exc: urllib.error.HTTPError) -> str:
@@ -234,11 +206,7 @@ class Finetune:
                 return {}
             return json.loads(body.decode("utf-8"))
 
-    def _backoff_delay(self, attempt: int, exc: Exception) -> float:
-        if isinstance(exc, urllib.error.HTTPError):
-            retry_after = _retry_after_seconds(exc.headers)
-            if retry_after is not None:
-                return retry_after
+    def _backoff_delay(self, attempt: int) -> float:
         max_delay = min(self.retry_max_delay, self.retry_base_delay * (2 ** attempt))
         return random.uniform(0.0, max_delay)
 
@@ -248,20 +216,22 @@ class Finetune:
         path: str,
         payload: Optional[dict] = None,
         query: Optional[dict] = None,
+        max_retries: Optional[int] = None,
     ) -> dict:
         last_error: Optional[Exception] = None
-        for attempt in range(self.max_retries + 1):
+        retries = self.max_retries if max_retries is None else max_retries
+        for attempt in range(retries + 1):
             try:
                 return self._request_json_once(method, path, payload=payload, query=query)
             except Exception as exc:
                 last_error = exc
-                if not _is_retryable_error(exc) or attempt == self.max_retries:
+                if not _is_retryable_error(exc) or attempt == retries:
                     if isinstance(exc, urllib.error.HTTPError):
                         _raise_http_error(path, exc)
                     raise FinetuneAPIError(f"{path} failed: {exc}") from exc
                 if isinstance(exc, urllib.error.HTTPError):
                     _close_http_error(exc)
-                time.sleep(self._backoff_delay(attempt, exc))
+                time.sleep(self._backoff_delay(attempt))
 
         raise FinetuneAPIError(f"{path} failed: {last_error}")
 
@@ -290,323 +260,94 @@ class Finetune:
                     raise FinetuneAPIError(f"{path} failed: {exc}") from exc
                 if isinstance(exc, urllib.error.HTTPError):
                     _close_http_error(exc)
-                await asyncio.sleep(self._backoff_delay(attempt, exc))
+                await asyncio.sleep(self._backoff_delay(attempt))
 
         raise FinetuneAPIError(f"{path} failed: {last_error}")
 
-    def _serialize_request(
-        self,
-        skill: str,
-        *,
-        image: Optional[Union[Image.Image, EncodedImage]] = None,
-        question: Optional[str] = None,
-        object: Optional[str] = None,
-        spatial_refs: Optional[Sequence[SpatialRef]] = None,
-        reasoning: bool = False,
-        settings: Optional[SamplingSettings] = None,
-    ) -> dict:
-        if skill == "query":
-            if question is None:
-                raise ValueError("question parameter is required")
-
-            payload = {
-                "skill": "query",
-                "question": question,
-            }
-            if image is not None:
-                payload["image_url"] = _encode_image(image).image_url
-            if spatial_refs is not None:
-                payload["spatial_refs"] = list(spatial_refs)
-            if reasoning:
-                payload["reasoning"] = True
-            settings_payload = dict(settings) if settings is not None else None
-            if settings_payload is not None:
-                payload["settings"] = settings_payload
-            return payload
-
-        if skill == "point":
-            if object is None:
-                raise ValueError("object parameter is required")
-            if image is None:
-                raise ValueError("image parameter is required")
-
-            payload = {
-                "skill": "point",
-                "object": object,
-                "image_url": _encode_image(image).image_url,
-            }
-            settings_payload = dict(settings) if settings is not None else None
-            if settings_payload is not None:
-                payload["settings"] = settings_payload
-            return payload
-
-        if skill == "detect":
-            if object is None:
-                raise ValueError("object parameter is required")
-            if image is None:
-                raise ValueError("image parameter is required")
-
-            payload = {
-                "skill": "detect",
-                "object": object,
-                "image_url": _encode_image(image).image_url,
-            }
-            settings_payload = dict(settings) if settings is not None else None
-            if settings_payload is not None:
-                payload["settings"] = settings_payload
-            return payload
-
-        raise ValueError("skill must be one of 'query', 'point', or 'detect'")
-
-    def _serialize_ground_truth(
-        self, skill: str, ground_truth: Optional[FinetuneGroundTruth]
-    ) -> Optional[dict]:
-        if ground_truth is None:
-            return None
-        if skill == "query":
-            raise ValueError("query rollouts do not support ground_truth")
-        if skill == "point":
-            return self._serialize_point_ground_truth(ground_truth)  # type: ignore[arg-type]
-        if skill == "detect":
-            return self._serialize_detect_ground_truth(ground_truth)  # type: ignore[arg-type]
-        raise ValueError(f"unsupported skill: {skill}")
-
-    def _serialize_point_ground_truth(self, ground_truth: PointGroundTruth) -> dict:
-        has_points = "points" in ground_truth
-        has_boxes = "boxes" in ground_truth
-        if has_points == has_boxes:
-            raise ValueError("point ground_truth requires exactly one of points or boxes")
-        if has_points:
-            return {"points": ground_truth["points"]}
-        return {"boxes": ground_truth["boxes"]}
-
-    def _serialize_detect_ground_truth(self, ground_truth: DetectGroundTruth) -> dict:
-        if "boxes" not in ground_truth:
-            raise ValueError("detect ground_truth requires boxes")
-        return {"boxes": ground_truth["boxes"]}
-
-    def _serialize_targets(self, request_payload: dict, targets: Sequence[dict]) -> List[dict]:
-        skill = request_payload["skill"]
-        if not targets:
-            raise ValueError("SFTGroup requires at least one target")
-        if skill == "query":
-            return [self._serialize_query_target(request_payload, target) for target in targets]
-        if skill == "point":
-            return [self._serialize_point_target(target) for target in targets]
-        if skill == "detect":
-            return [self._serialize_detect_target(target) for target in targets]
-        raise ValueError(f"unsupported skill: {skill}")
-
-    def _serialize_query_target(self, request_payload: dict, target: QueryTarget) -> dict:
-        answer = target.get("answer")
-        if answer is None:
-            raise ValueError("query SFT targets require answer")
-        payload = {"answer": answer}
-        if request_payload.get("reasoning"):
-            reasoning = target.get("reasoning")
-            if reasoning is None:
-                raise ValueError("query SFT targets require reasoning when request.reasoning is true")
-            payload["reasoning"] = reasoning
-        elif "reasoning" in target:
-            raise ValueError("query SFT targets should omit reasoning when request.reasoning is false")
+    def _request_payload(self, request: RolloutRequest) -> SkillRequest:
+        payload: SkillRequest = {"skill": request.skill}
+        if request.image is not None:
+            payload["image_url"] = _encode_image(request.image).image_url
+        if request.question is not None:
+            payload["question"] = request.question
+        if request.object is not None:
+            payload["object"] = request.object
+        if request.spatial_refs is not None:
+            payload["spatial_refs"] = list(request.spatial_refs)
+        if request.reasoning:
+            payload["reasoning"] = True
+        if request.settings is not None:
+            payload["settings"] = dict(request.settings)
         return payload
 
-    def _serialize_point_target(self, target: PointTarget) -> dict:
-        has_points = "points" in target
-        has_boxes = "boxes" in target
-        if has_points == has_boxes:
-            raise ValueError("point SFT targets require exactly one of points or boxes")
-        if has_points:
-            return {"points": target["points"]}
-        return {"boxes": target["boxes"]}
-
-    def _serialize_detect_target(self, target: DetectTarget) -> dict:
-        if "boxes" not in target:
-            raise ValueError("detect SFT targets require boxes")
-        return {"boxes": target["boxes"]}
-
-    def _serialize_group_request(
-        self,
-        group: Union[RolloutGroup, RLGroup[RolloutOutput], SFTGroup],
-    ) -> dict:
-        return self._serialize_request(
-            group.skill,
-            image=group.image,
-            question=group.question,
-            object=group.object,
-            spatial_refs=group.spatial_refs,
-            reasoning=group.reasoning,
-            settings=None if isinstance(group, SFTGroup) else group.settings,
-        )
-
-    def _rl_group_from_result(
-        self,
-        group: RolloutGroup,
-        request_payload: dict,
-        result: dict,
-    ) -> RLGroup[RolloutOutput]:
-        rollouts_payload = result.get("rollouts", [])
-        return RLGroup(
-            skill=group.skill,
-            rollouts=[copy.deepcopy(rollout.get("output", {})) for rollout in rollouts_payload],
-            image=group.image,
-            question=group.question,
-            object=group.object,
-            spatial_refs=group.spatial_refs,
-            reasoning=group.reasoning,
-            settings=group.settings,
-            rewards=result.get("rewards"),
-            _request_payload=result.get("request", request_payload),
-            _rollouts_payload=rollouts_payload,
-        )
-
-    def _rollouts_from_group(self, group: RolloutGroup) -> RLGroup[RolloutOutput]:
-        if group.num_rollouts < 1 or group.num_rollouts > 16:
-            raise ValueError("num_rollouts must be between 1 and 16")
-
-        request_payload = self._serialize_group_request(group)
+    def _rollouts_payload(self, request: RolloutRequest) -> dict:
         payload = {
             "finetune_id": self.finetune_id,
-            "num_rollouts": group.num_rollouts,
-            "request": request_payload,
+            "num_rollouts": request.num_rollouts,
+            "request": self._request_payload(request),
         }
-        ground_truth_payload = self._serialize_ground_truth(
-            request_payload["skill"], group.ground_truth
-        )
-        if ground_truth_payload is not None:
-            payload["ground_truth"] = ground_truth_payload
+        if request.ground_truth is not None:
+            payload["ground_truth"] = dict(request.ground_truth)
+        return payload
 
-        result = self._request_json("POST", "/rollouts", payload=payload)
-        return self._rl_group_from_result(group, request_payload, result)
+    def _rl_group_from_response(self, response: RolloutsResponse) -> RLGroup:
+        group: RLGroup = {
+            "mode": "rl",
+            "request": response["request"],
+            "rollouts": response.get("rollouts", []),
+        }
+        rewards = response.get("rewards")
+        if rewards is not None:
+            group["rewards"] = rewards
+        return group
+
+    def rollouts(self, request: RolloutRequest) -> RolloutsResponse:
+        """Generate rollouts for a single request.
+
+        Returns the raw `/rollouts` response with `request`, `rollouts`, and
+        optional `rewards`.
+        """
+        return self._request_json(
+            "POST",
+            "/rollouts",
+            payload=self._rollouts_payload(request),
+        )
 
     def delete(self) -> None:
         self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
 
-    def query_rollouts(
-        self,
-        image: Optional[Union[Image.Image, EncodedImage]] = None,
-        question: Optional[str] = None,
-        num_rollouts: int = 1,
-        settings: Optional[SamplingSettings] = None,
-        reasoning: bool = False,
-        spatial_refs: Optional[Sequence[SpatialRef]] = None,
-    ) -> RLGroup[QueryOutput]:
-        """Generate query rollouts.
-
-        Query settings typically use `temperature`, `top_p`, and `max_tokens`.
-
-        Returns:
-            RLGroup: `group.rollouts` is a list of query output dicts such as
-            `{"answer": "People are smiling for a photo."}`. When `reasoning=True`,
-            each rollout may also include `{"reasoning": ...}`.
-        """
-        if question is None:
-            raise ValueError("question parameter is required")
-        group = self._rollouts_from_group(
-            RolloutGroup.query(
-                question=question,
-                image=image,
-                num_rollouts=num_rollouts,
-                settings=settings,
-                reasoning=reasoning,
-                spatial_refs=list(spatial_refs) if spatial_refs is not None else None,
-            )
+    async def _rollouts_async(self, request: RolloutRequest) -> RolloutsResponse:
+        return await self._request_json_async(
+            "POST",
+            "/rollouts",
+            payload=self._rollouts_payload(request),
         )
-        return cast(RLGroup[QueryOutput], group)
 
-    def point_rollouts(
+    def batch_rollouts(
         self,
-        image: Union[Image.Image, EncodedImage],
-        object: str,
-        num_rollouts: int = 1,
-        settings: Optional[SamplingSettings] = None,
-        ground_truth: Optional[PointGroundTruth] = None,
-    ) -> RLGroup[PointOutput]:
-        """Generate point rollouts.
-
-        Point settings typically use `temperature`, `top_p`, and `max_objects`.
-
-        Returns:
-            RLGroup: `group.rollouts` is a list of point output dicts such as
-            `{"points": [{"x": 0.24, "y": 0.58}, {"x": 0.71, "y": 0.61}]}`.
-        """
-        group = self._rollouts_from_group(
-            RolloutGroup.point(
-                image=image,
-                object=object,
-                num_rollouts=num_rollouts,
-                settings=settings,
-                ground_truth=ground_truth,
-            )
-        )
-        return cast(RLGroup[PointOutput], group)
-
-    def detect_rollouts(
-        self,
-        image: Union[Image.Image, EncodedImage],
-        object: str,
-        num_rollouts: int = 1,
-        settings: Optional[SamplingSettings] = None,
-        ground_truth: Optional[DetectGroundTruth] = None,
-    ) -> RLGroup[DetectOutput]:
-        """Generate detect rollouts.
-
-        Detect settings typically use `temperature`, `top_p`, and `max_objects`.
-
-        Returns:
-            RLGroup: `group.rollouts` is a list of detect output dicts such as
-            `{"objects": [{"x_min": 0.12, "y_min": 0.08, "x_max": 0.41, "y_max": 0.95}]}`.
-        """
-        group = self._rollouts_from_group(
-            RolloutGroup.detect(
-                image=image,
-                object=object,
-                num_rollouts=num_rollouts,
-                settings=settings,
-                ground_truth=ground_truth,
-            )
-        )
-        return cast(RLGroup[DetectOutput], group)
-
-    async def _rollouts_async(self, group: RolloutGroup) -> RLGroup[RolloutOutput]:
-        if group.num_rollouts < 1 or group.num_rollouts > 16:
-            raise ValueError("num_rollouts must be between 1 and 16")
-
-        request_payload = self._serialize_group_request(group)
-        payload = {
-            "finetune_id": self.finetune_id,
-            "num_rollouts": group.num_rollouts,
-            "request": request_payload,
-        }
-        ground_truth_payload = self._serialize_ground_truth(
-            request_payload["skill"], group.ground_truth
-        )
-        if ground_truth_payload is not None:
-            payload["ground_truth"] = ground_truth_payload
-
-        result = await self._request_json_async("POST", "/rollouts", payload=payload)
-        return self._rl_group_from_result(group, request_payload, result)
-
-    def rollout_groups(
-        self,
-        groups: Sequence[RolloutGroup],
+        requests: Sequence[RolloutRequest],
         max_concurrency: int = 4,
-    ) -> List[RLGroup[RolloutOutput]]:
+    ) -> List[RLGroup]:
+        """Generate multiple rollout requests in parallel.
+
+        Returns RL groups with `mode`, `request`, and `rollouts` populated.
+        Fill `group["rewards"]` before calling `train_step(...)`.
+        """
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be at least 1")
-        groups_list = list(groups)
-        if not groups_list:
+        requests_list = list(requests)
+        if not requests_list:
             return []
         return self._run_async(
-            self._rollout_groups_async(groups_list, max_concurrency=max_concurrency)
+            self._batch_rollouts_async(requests_list, max_concurrency=max_concurrency)
         )
 
-    async def _rollout_groups_async(
+    async def _batch_rollouts_async(
         self,
-        groups: Sequence[RolloutGroup],
+        requests: Sequence[RolloutRequest],
         max_concurrency: int,
-    ) -> List[RLGroup[RolloutOutput]]:
-        results: List[Optional[RLGroup[RolloutOutput]]] = [None] * len(groups)
+    ) -> List[RLGroup]:
+        results: List[Optional[RLGroup]] = [None] * len(requests)
         next_index = 0
         first_error: Optional[BaseException] = None
         lock = asyncio.Lock()
@@ -617,13 +358,14 @@ class Finetune:
 
             while True:
                 async with lock:
-                    if stop.is_set() or next_index >= len(groups):
+                    if stop.is_set() or next_index >= len(requests):
                         return
                     index = next_index
                     next_index += 1
 
                 try:
-                    results[index] = await self._rollouts_async(groups[index])
+                    response = await self._rollouts_async(requests[index])
+                    results[index] = self._rl_group_from_response(response)
                 except Exception as exc:
                     if not stop.is_set():
                         first_error = exc
@@ -632,7 +374,7 @@ class Finetune:
 
         tasks = [
             asyncio.create_task(worker())
-            for _ in range(min(max_concurrency, len(groups)))
+            for _ in range(min(max_concurrency, len(requests)))
         ]
         await asyncio.gather(*tasks)
 
@@ -643,7 +385,7 @@ class Finetune:
 
     def train_step(
         self,
-        groups: Sequence[Union[RLGroup[RolloutOutput], SFTGroup]],
+        groups: Sequence[Union[RLGroup, SFTGroup]],
         lr: float = 0.002,
     ) -> TrainStepOutput:
         if not groups:
@@ -651,54 +393,36 @@ class Finetune:
 
         payload_groups = []
         for group in groups:
-            if isinstance(group, RLGroup):
-                if group.rewards is None:
+            mode = group.get("mode")
+            if mode == "rl":
+                rewards = group.get("rewards")
+                rollouts = group.get("rollouts")
+                if rewards is None:
                     raise ValueError("RLGroup rewards must be set before train_step")
-                request_payload = group._request_payload
-                if request_payload is None:
-                    request_payload = self._serialize_group_request(group)
-                rollouts_payload = group._rollouts_payload
-                if rollouts_payload is None:
-                    raise ValueError(
-                        "RLGroup rollouts must come from ft.*_rollouts before train_step"
-                    )
-                if len(group.rollouts) != len(rollouts_payload):
-                    raise ValueError(
-                        "RLGroup rollouts must not be mutated after ft.*_rollouts"
-                    )
-                if len(group.rewards) != len(rollouts_payload):
+                if rollouts is None:
+                    raise ValueError("RLGroup requires rollouts")
+                if len(rewards) != len(rollouts):
                     raise ValueError("rewards must match rollouts length")
-                payload_groups.append(
-                    {
-                        "mode": "rl",
-                        "request": request_payload,
-                        "rollouts": rollouts_payload,
-                        "rewards": group.rewards,
-                    }
-                )
+                payload_groups.append(group)
                 continue
 
-            if isinstance(group, SFTGroup):
-                request_payload = self._serialize_group_request(group)
-                payload_groups.append(
-                    {
-                        "mode": "sft",
-                        "request": request_payload,
-                        "targets": self._serialize_targets(
-                            request_payload, group.targets
-                        ),
-                    }
-                )
+            if mode == "sft":
+                payload_groups.append(group)
                 continue
 
-            raise ValueError("train_step groups must be RLGroup or SFTGroup")
+            raise ValueError("train_step groups must have mode 'rl' or 'sft'")
 
         payload = {
             "finetune_id": self.finetune_id,
             "groups": payload_groups,
             "lr": lr,
         }
-        result = self._request_json("POST", "/train_step", payload=payload)
+        result = self._request_json(
+            "POST",
+            "/train_step",
+            payload=payload,
+            max_retries=0,
+        )
         return {key: result[key] for key in _TRAIN_STEP_OUTPUT_KEYS if key in result}
 
     def log_metrics(
@@ -801,11 +525,6 @@ class Finetune:
         return result["value"]
 
 
-def _validate_name(name: str):
-    if not _NAME_PATTERN.fullmatch(name):
-        raise ValueError("name must use only alphanumeric characters, hyphens, or underscores")
-
-
 def ft(
     api_key: Optional[str] = None,
     *,
@@ -841,8 +560,6 @@ def ft(
 
     if name is None or rank is None:
         raise ValueError("ft requires either finetune_id or both name and rank")
-
-    _validate_name(name)
 
     client = Finetune(
         api_key=api_key,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -63,9 +63,9 @@ def _is_retryable(exc: Exception) -> bool:
     return isinstance(exc, (TimeoutError, socket.timeout))
 
 
-_MAX_RETRIES = 5
+_MAX_RETRIES = 10
 _RETRY_BASE_DELAY = 0.5
-_RETRY_MAX_DELAY = 8.0
+_RETRY_MAX_DELAY = 30.0
 _REQUEST_TIMEOUT = 60.0
 
 

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -64,6 +64,12 @@ def _is_retryable(exc: Exception) -> bool:
     return isinstance(exc, (TimeoutError, socket.timeout))
 
 
+_MAX_RETRIES = 5
+_RETRY_BASE_DELAY = 0.5
+_RETRY_MAX_DELAY = 8.0
+_REQUEST_TIMEOUT = 60.0
+
+
 class Finetune:
     def __init__(
         self,
@@ -73,29 +79,12 @@ class Finetune:
         finetune_id: str,
         name: str,
         rank: int,
-        max_retries: int = 5,
-        retry_base_delay: float = 0.5,
-        retry_max_delay: float = 8.0,
-        timeout: float = 60.0,
     ):
-        if max_retries < 0:
-            raise ValueError("max_retries must be non-negative")
-        if retry_base_delay < 0:
-            raise ValueError("retry_base_delay must be non-negative")
-        if retry_max_delay < 0:
-            raise ValueError("retry_max_delay must be non-negative")
-        if timeout <= 0:
-            raise ValueError("timeout must be positive")
-
         self.api_key = api_key
         self.endpoint = endpoint.rstrip("/")
         self.finetune_id = finetune_id
         self.name = name
         self.rank = rank
-        self.max_retries = max_retries
-        self.retry_base_delay = retry_base_delay
-        self.retry_max_delay = retry_max_delay
-        self.timeout = timeout
 
     def _headers(self, has_body: bool = False) -> Dict[str, str]:
         headers = {
@@ -115,7 +104,7 @@ class Finetune:
                 url = f"{url}?{urllib.parse.urlencode(items)}"
         return url
 
-    def _request_json_once(
+    def _request_json(
         self,
         method: str,
         path: str,
@@ -123,41 +112,26 @@ class Finetune:
         query: Optional[dict] = None,
     ) -> dict:
         data = None if payload is None else json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            self._url(path, query=query),
-            data=data,
-            headers=self._headers(has_body=payload is not None),
-            method=method,
-        )
-
-        with urllib.request.urlopen(req, timeout=self.timeout) as response:
-            body = response.read()
-            if not body:
-                return {}
-            return json.loads(body.decode("utf-8"))
-
-    def _backoff_delay(self, attempt: int) -> float:
-        max_delay = min(self.retry_max_delay, self.retry_base_delay * (2 ** attempt))
-        return random.uniform(0.0, max_delay)
-
-    def _request_json(
-        self,
-        method: str,
-        path: str,
-        payload: Optional[dict] = None,
-        query: Optional[dict] = None,
-        max_retries: Optional[int] = None,
-    ) -> dict:
-        retries = self.max_retries if max_retries is None else max_retries
         last_exc: Optional[Exception] = None
-        for attempt in range(retries + 1):
+        for attempt in range(_MAX_RETRIES + 1):
             try:
-                return self._request_json_once(method, path, payload=payload, query=query)
+                req = urllib.request.Request(
+                    self._url(path, query=query),
+                    data=data,
+                    headers=self._headers(has_body=payload is not None),
+                    method=method,
+                )
+                with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as response:
+                    body = response.read()
+                    if not body:
+                        return {}
+                    return json.loads(body.decode("utf-8"))
             except Exception as exc:
                 last_exc = exc
-                if not _is_retryable(exc) or attempt == retries:
+                if not _is_retryable(exc) or attempt == _MAX_RETRIES:
                     raise
-                time.sleep(self._backoff_delay(attempt))
+                max_delay = min(_RETRY_MAX_DELAY, _RETRY_BASE_DELAY * (2 ** attempt))
+                time.sleep(random.uniform(0.0, max_delay))
         raise last_exc  # unreachable, but keeps the type checker happy
 
     def _request_payload(
@@ -360,12 +334,7 @@ class Finetune:
             "groups": list(groups),
             "lr": lr,
         }
-        result = self._request_json(
-            "POST",
-            "/train_step",
-            payload=payload,
-            max_retries=0,
-        )
+        result = self._request_json("POST", "/train_step", payload=payload)
         return result
 
     def log_metrics(
@@ -425,10 +394,6 @@ def ft(
     rank: Optional[int] = None,
     finetune_id: Optional[str] = None,
     endpoint: str = DEFAULT_TUNING_ENDPOINT,
-    max_retries: int = 5,
-    retry_base_delay: float = 0.5,
-    retry_max_delay: float = 8.0,
-    timeout: float = 60.0,
 ) -> Finetune:
     if finetune_id is not None:
         if name is not None or rank is not None:
@@ -439,10 +404,6 @@ def ft(
             finetune_id=finetune_id,
             name="",
             rank=0,
-            max_retries=max_retries,
-            retry_base_delay=retry_base_delay,
-            retry_max_delay=retry_max_delay,
-            timeout=timeout,
         )
         result = client._request_json("GET", f"/finetunes/{finetune_id}")
         finetune: FinetuneInfo = result.get("finetune", result)
@@ -460,10 +421,6 @@ def ft(
         finetune_id="",
         name=name,
         rank=rank,
-        max_retries=max_retries,
-        retry_base_delay=retry_base_delay,
-        retry_max_delay=retry_max_delay,
-        timeout=timeout,
     )
     result = client._request_json(
         "POST",

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -74,7 +74,7 @@ class Finetune:
     def __init__(
         self,
         *,
-        api_key: Optional[str],
+        api_key: str,
         endpoint: str,
         finetune_id: str,
         name: str,
@@ -89,11 +89,10 @@ class Finetune:
     def _headers(self, has_body: bool = False) -> Dict[str, str]:
         headers = {
             "User-Agent": f"moondream-python/{__version__}",
+            "X-Moondream-Auth": self.api_key,
         }
         if has_body:
             headers["Content-Type"] = "application/json"
-        if self.api_key:
-            headers["X-Moondream-Auth"] = self.api_key
         return headers
 
     def _url(self, path: str, query: Optional[dict] = None) -> str:
@@ -388,7 +387,7 @@ class Finetune:
 
 
 def ft(
-    api_key: Optional[str] = None,
+    api_key: str,
     *,
     name: Optional[str] = None,
     rank: Optional[int] = None,

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -11,7 +11,7 @@ import urllib.parse
 import urllib.request
 from io import BytesIO
 from importlib.metadata import version as _pkg_version
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Union
 
 from PIL import Image
 
@@ -20,21 +20,19 @@ from .types import (
     CheckpointDownload,
     CheckpointInfo,
     CheckpointListOutput,
-    DetectFinetuneRequest,
     DetectGroundTruth,
     DetectTarget,
-    FinetuneSamplingSettings,
     FinetuneGroundTruth,
     FinetuneInfo,
-    FinetuneRequest,
-    PointFinetuneRequest,
+    EncodedImage,
     PointGroundTruth,
     PointTarget,
-    QueryFinetuneRequest,
     QueryTarget,
     RLGroup,
-    RolloutSpec,
+    RolloutGroup,
+    SamplingSettings,
     SFTGroup,
+    SpatialRef,
     TrainStepOutput,
 )
 
@@ -276,7 +274,7 @@ class Finetune:
         raise FinetuneAPIError(f"{path} failed: {last_error}")
 
     def _validate_rollout_settings(
-        self, skill: str, settings: Optional[FinetuneSamplingSettings]
+        self, skill: str, settings: Optional[SamplingSettings]
     ) -> Optional[dict]:
         if settings is None:
             return None
@@ -285,76 +283,71 @@ class Finetune:
             raise ValueError("query settings do not accept max_objects")
         if skill in ("point", "detect") and "max_tokens" in settings_dict:
             raise ValueError(f"{skill} settings do not accept max_tokens")
-        return settings_dict
+        return settings_dict or None
 
-    def _serialize_request(self, request: FinetuneRequest) -> dict:
-        skill = request.get("skill")
+    def _serialize_request(
+        self,
+        skill: str,
+        *,
+        image: Optional[Union[Image.Image, EncodedImage]] = None,
+        question: Optional[str] = None,
+        object: Optional[str] = None,
+        spatial_refs: Optional[Sequence[SpatialRef]] = None,
+        reasoning: bool = False,
+        settings: Optional[SamplingSettings] = None,
+    ) -> dict:
         if skill == "query":
-            return self._serialize_query_request(request)
+            if question is None:
+                raise ValueError("question parameter is required")
+
+            payload = {
+                "skill": "query",
+                "question": question,
+            }
+            if image is not None:
+                payload["image_url"] = _encode_image(image).image_url
+            if spatial_refs is not None:
+                payload["spatial_refs"] = list(spatial_refs)
+            if reasoning:
+                payload["reasoning"] = True
+            settings_payload = self._validate_rollout_settings("query", settings)
+            if settings_payload is not None:
+                payload["settings"] = settings_payload
+            return payload
+
         if skill == "point":
-            return self._serialize_point_request(request)
+            if object is None:
+                raise ValueError("object parameter is required")
+            if image is None:
+                raise ValueError("image parameter is required")
+
+            payload = {
+                "skill": "point",
+                "object": object,
+                "image_url": _encode_image(image).image_url,
+            }
+            settings_payload = self._validate_rollout_settings("point", settings)
+            if settings_payload is not None:
+                payload["settings"] = settings_payload
+            return payload
+
         if skill == "detect":
-            return self._serialize_detect_request(request)
-        raise ValueError("request.skill must be one of 'query', 'point', or 'detect'")
+            if object is None:
+                raise ValueError("object parameter is required")
+            if image is None:
+                raise ValueError("image parameter is required")
 
-    def _serialize_query_request(self, request: QueryFinetuneRequest) -> dict:
-        question = request.get("question")
-        if question is None:
-            raise ValueError("query request requires question")
+            payload = {
+                "skill": "detect",
+                "object": object,
+                "image_url": _encode_image(image).image_url,
+            }
+            settings_payload = self._validate_rollout_settings("detect", settings)
+            if settings_payload is not None:
+                payload["settings"] = settings_payload
+            return payload
 
-        payload = {
-            "skill": "query",
-            "question": question,
-        }
-        image = request.get("image")
-        if image is not None:
-            payload["image_url"] = _encode_image(image).image_url
-        spatial_refs = request.get("spatial_refs")
-        if spatial_refs is not None:
-            payload["spatial_refs"] = spatial_refs
-        reasoning = request.get("reasoning")
-        if reasoning is not None:
-            payload["reasoning"] = reasoning
-        settings = self._validate_rollout_settings("query", request.get("settings"))
-        if settings is not None:
-            payload["settings"] = settings
-        return payload
-
-    def _serialize_point_request(self, request: PointFinetuneRequest) -> dict:
-        object_name = request.get("object")
-        image = request.get("image")
-        if object_name is None:
-            raise ValueError("point request requires object")
-        if image is None:
-            raise ValueError("point request requires image")
-
-        payload = {
-            "skill": "point",
-            "object": object_name,
-            "image_url": _encode_image(image).image_url,
-        }
-        settings = self._validate_rollout_settings("point", request.get("settings"))
-        if settings is not None:
-            payload["settings"] = settings
-        return payload
-
-    def _serialize_detect_request(self, request: DetectFinetuneRequest) -> dict:
-        object_name = request.get("object")
-        image = request.get("image")
-        if object_name is None:
-            raise ValueError("detect request requires object")
-        if image is None:
-            raise ValueError("detect request requires image")
-
-        payload = {
-            "skill": "detect",
-            "object": object_name,
-            "image_url": _encode_image(image).image_url,
-        }
-        settings = self._validate_rollout_settings("detect", request.get("settings"))
-        if settings is not None:
-            payload["settings"] = settings
-        return payload
+        raise ValueError("skill must be one of 'query', 'point', or 'detect'")
 
     def _serialize_ground_truth(
         self, skill: str, ground_truth: Optional[FinetuneGroundTruth]
@@ -423,82 +416,160 @@ class Finetune:
             raise ValueError("detect SFT targets require boxes")
         return {"boxes": target["boxes"]}
 
-    def delete(self) -> None:
-        self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
-
-    def rollouts(
+    def _serialize_group_request(
         self,
-        request: FinetuneRequest,
-        num_rollouts: int = 1,
-        ground_truth: Optional[FinetuneGroundTruth] = None,
+        group: Union[RolloutGroup, RLGroup, SFTGroup],
+    ) -> dict:
+        return self._serialize_request(
+            group.skill,
+            image=group.image,
+            question=group.question,
+            object=group.object,
+            spatial_refs=group.spatial_refs,
+            reasoning=group.reasoning,
+            settings=group.settings,
+        )
+
+    def _rl_group_from_result(
+        self,
+        group: RolloutGroup,
+        request_payload: dict,
+        result: dict,
     ) -> RLGroup:
-        if num_rollouts < 1 or num_rollouts > 16:
+        rollouts_payload = result.get("rollouts", [])
+        return RLGroup(
+            skill=group.skill,
+            rollouts=[dict(rollout.get("output", {})) for rollout in rollouts_payload],
+            image=group.image,
+            question=group.question,
+            object=group.object,
+            spatial_refs=group.spatial_refs,
+            reasoning=group.reasoning,
+            settings=group.settings,
+            rewards=result.get("rewards"),
+            _request_payload=result.get("request", request_payload),
+            _rollouts_payload=rollouts_payload,
+        )
+
+    def _rollouts_from_group(self, group: RolloutGroup) -> RLGroup:
+        if group.num_rollouts < 1 or group.num_rollouts > 16:
             raise ValueError("num_rollouts must be between 1 and 16")
 
-        request_payload = self._serialize_request(request)
+        request_payload = self._serialize_group_request(group)
         payload = {
             "finetune_id": self.finetune_id,
-            "num_rollouts": num_rollouts,
+            "num_rollouts": group.num_rollouts,
             "request": request_payload,
         }
         ground_truth_payload = self._serialize_ground_truth(
-            request_payload["skill"], ground_truth
+            request_payload["skill"], group.ground_truth
         )
         if ground_truth_payload is not None:
             payload["ground_truth"] = ground_truth_payload
 
         result = self._request_json("POST", "/rollouts", payload=payload)
-        return RLGroup(
-            request=request,
-            rollouts=result["rollouts"],
-            rewards=result.get("rewards"),
-            _request_payload=result.get("request", request_payload),
+        return self._rl_group_from_result(group, request_payload, result)
+
+    def delete(self) -> None:
+        self._request_json("DELETE", f"/finetunes/{self.finetune_id}")
+
+    def query_rollouts(
+        self,
+        image: Optional[Union[Image.Image, EncodedImage]] = None,
+        question: Optional[str] = None,
+        num_rollouts: int = 1,
+        settings: Optional[SamplingSettings] = None,
+        reasoning: bool = False,
+        spatial_refs: Optional[Sequence[SpatialRef]] = None,
+    ) -> RLGroup:
+        if question is None:
+            raise ValueError("question parameter is required")
+        return self._rollouts_from_group(
+            RolloutGroup.query(
+                question=question,
+                image=image,
+                num_rollouts=num_rollouts,
+                settings=settings,
+                reasoning=reasoning,
+                spatial_refs=list(spatial_refs) if spatial_refs is not None else None,
+            )
         )
 
-    async def _rollouts_async(self, spec: RolloutSpec) -> RLGroup:
-        if spec.num_rollouts < 1 or spec.num_rollouts > 16:
+    def point_rollouts(
+        self,
+        image: Union[Image.Image, EncodedImage],
+        object: str,
+        num_rollouts: int = 1,
+        settings: Optional[SamplingSettings] = None,
+        ground_truth: Optional[PointGroundTruth] = None,
+    ) -> RLGroup:
+        return self._rollouts_from_group(
+            RolloutGroup.point(
+                image=image,
+                object=object,
+                num_rollouts=num_rollouts,
+                settings=settings,
+                ground_truth=ground_truth,
+            )
+        )
+
+    def detect_rollouts(
+        self,
+        image: Union[Image.Image, EncodedImage],
+        object: str,
+        num_rollouts: int = 1,
+        settings: Optional[SamplingSettings] = None,
+        ground_truth: Optional[DetectGroundTruth] = None,
+    ) -> RLGroup:
+        return self._rollouts_from_group(
+            RolloutGroup.detect(
+                image=image,
+                object=object,
+                num_rollouts=num_rollouts,
+                settings=settings,
+                ground_truth=ground_truth,
+            )
+        )
+
+    async def _rollouts_async(self, group: RolloutGroup) -> RLGroup:
+        if group.num_rollouts < 1 or group.num_rollouts > 16:
             raise ValueError("num_rollouts must be between 1 and 16")
 
-        request_payload = self._serialize_request(spec.request)
+        request_payload = self._serialize_group_request(group)
         payload = {
             "finetune_id": self.finetune_id,
-            "num_rollouts": spec.num_rollouts,
+            "num_rollouts": group.num_rollouts,
             "request": request_payload,
         }
         ground_truth_payload = self._serialize_ground_truth(
-            request_payload["skill"], spec.ground_truth
+            request_payload["skill"], group.ground_truth
         )
         if ground_truth_payload is not None:
             payload["ground_truth"] = ground_truth_payload
 
         result = await self._request_json_async("POST", "/rollouts", payload=payload)
-        return RLGroup(
-            request=spec.request,
-            rollouts=result["rollouts"],
-            rewards=result.get("rewards"),
-            _request_payload=result.get("request", request_payload),
-        )
+        return self._rl_group_from_result(group, request_payload, result)
 
     def rollout_groups(
         self,
-        specs: Sequence[RolloutSpec],
+        groups: Sequence[RolloutGroup],
         max_concurrency: int = 4,
     ) -> List[RLGroup]:
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be at least 1")
-        specs_list = list(specs)
-        if not specs_list:
+        groups_list = list(groups)
+        if not groups_list:
             return []
         return self._run_async(
-            self._rollout_groups_async(specs_list, max_concurrency=max_concurrency)
+            self._rollout_groups_async(groups_list, max_concurrency=max_concurrency)
         )
 
     async def _rollout_groups_async(
         self,
-        specs: Sequence[RolloutSpec],
+        groups: Sequence[RolloutGroup],
         max_concurrency: int,
     ) -> List[RLGroup]:
-        results: List[Optional[RLGroup]] = [None] * len(specs)
+        results: List[Optional[RLGroup]] = [None] * len(groups)
         next_index = 0
         first_error: Optional[BaseException] = None
         lock = asyncio.Lock()
@@ -509,13 +580,13 @@ class Finetune:
 
             while True:
                 async with lock:
-                    if stop.is_set() or next_index >= len(specs):
+                    if stop.is_set() or next_index >= len(groups):
                         return
                     index = next_index
                     next_index += 1
 
                 try:
-                    results[index] = await self._rollouts_async(specs[index])
+                    results[index] = await self._rollouts_async(groups[index])
                 except Exception as exc:
                     if not stop.is_set():
                         first_error = exc
@@ -524,7 +595,7 @@ class Finetune:
 
         tasks = [
             asyncio.create_task(worker())
-            for _ in range(min(max_concurrency, len(specs)))
+            for _ in range(min(max_concurrency, len(groups)))
         ]
         await asyncio.gather(*tasks)
 
@@ -535,7 +606,7 @@ class Finetune:
 
     def train_step(
         self,
-        groups: Sequence[object],
+        groups: Sequence[Union[RLGroup, SFTGroup]],
         lr: float = 0.002,
     ) -> TrainStepOutput:
         if not groups:
@@ -548,19 +619,24 @@ class Finetune:
                     raise ValueError("RLGroup rewards must be set before train_step")
                 request_payload = group._request_payload
                 if request_payload is None:
-                    request_payload = self._serialize_request(group.request)
+                    request_payload = self._serialize_group_request(group)
+                rollouts_payload = group._rollouts_payload
+                if rollouts_payload is None:
+                    raise ValueError(
+                        "RLGroup rollouts must come from ft.*_rollouts before train_step"
+                    )
                 payload_groups.append(
                     {
                         "mode": "rl",
                         "request": request_payload,
-                        "rollouts": group.rollouts,
+                        "rollouts": rollouts_payload,
                         "rewards": group.rewards,
                     }
                 )
                 continue
 
             if isinstance(group, SFTGroup):
-                request_payload = self._serialize_request(group.request)
+                request_payload = self._serialize_group_request(group)
                 payload_groups.append(
                     {
                         "mode": "sft",

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -17,12 +17,14 @@ from PIL import Image
 from .types import (
     Base64EncodedImage,
     CheckpointListOutput,
+    FinetuneGroundTruth,
     FinetuneInfo,
     EncodedImage,
     MetricsLogOutput,
     RLGroup,
     RolloutRequest,
     RolloutsResponse,
+    SamplingSettings,
     SaveCheckpointOutput,
     SFTTarget,
     Skill,
@@ -248,27 +250,57 @@ class Finetune:
     def _rollouts_payload(self, request: RolloutRequest) -> dict:
         payload = {
             "finetune_id": self.finetune_id,
-            "num_rollouts": request.num_rollouts,
+            "num_rollouts": request.get("num_rollouts", 1),
             "request": self._request_payload(
-                skill=request.skill,
-                image=request.image,
-                question=request.question,
-                object=request.object,
-                spatial_refs=request.spatial_refs,
-                reasoning=request.reasoning,
-                settings=request.settings,
+                skill=request["skill"],
+                image=request.get("image"),
+                question=request.get("question"),
+                object=request.get("object"),
+                spatial_refs=request.get("spatial_refs"),
+                reasoning=request.get("reasoning", False),
+                settings=request.get("settings"),
             ),
         }
-        if request.ground_truth is not None:
-            payload["ground_truth"] = dict(request.ground_truth)
+        ground_truth = request.get("ground_truth")
+        if ground_truth is not None:
+            payload["ground_truth"] = dict(ground_truth)
         return payload
 
-    def rollouts(self, request: RolloutRequest) -> RolloutsResponse:
+    def rollouts(
+        self,
+        skill: Skill,
+        *,
+        image: Optional[Union[Image.Image, EncodedImage]] = None,
+        question: Optional[str] = None,
+        object: Optional[str] = None,
+        num_rollouts: int = 1,
+        settings: Optional[SamplingSettings] = None,
+        reasoning: bool = False,
+        spatial_refs: Optional[Sequence[SpatialRef]] = None,
+        ground_truth: Optional[FinetuneGroundTruth] = None,
+    ) -> RolloutsResponse:
         """Generate rollouts for a single request.
 
         Returns the raw `/rollouts` response with `request`, `rollouts`, and
         optional `rewards`.
         """
+        request: RolloutRequest = {"skill": skill}
+        if image is not None:
+            request["image"] = image
+        if question is not None:
+            request["question"] = question
+        if object is not None:
+            request["object"] = object
+        if num_rollouts != 1:
+            request["num_rollouts"] = num_rollouts
+        if settings is not None:
+            request["settings"] = settings
+        if reasoning:
+            request["reasoning"] = reasoning
+        if spatial_refs is not None:
+            request["spatial_refs"] = list(spatial_refs)
+        if ground_truth is not None:
+            request["ground_truth"] = ground_truth
         return self._request_json(
             "POST",
             "/rollouts",
@@ -334,7 +366,7 @@ class Finetune:
                         return
 
                     try:
-                        response = self.rollouts(request)
+                        response = self.rollouts(**request)
                     except Exception as exc:
                         stop.set()
                         while True:

--- a/moondream/finetune.py
+++ b/moondream/finetune.py
@@ -37,7 +37,7 @@ __version__ = _pkg_version("moondream")
 
 DEFAULT_TUNING_ENDPOINT = "https://api.moondream.ai/v1/tuning"
 
-_RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504, 524}
+_RETRY_STATUS_CODES = {408, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524}
 
 
 def _encode_image(image) -> Base64EncodedImage:

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import Generator, List, Literal, Optional, Sequence, TypedDict, Union
 
 from PIL import Image
@@ -283,7 +283,7 @@ class RolloutGroup:
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class RLGroup:
     skill: Literal["query", "point", "detect"]
     rollouts: List[RolloutOutput]
@@ -299,11 +299,14 @@ class RLGroup:
         default=None, repr=False, compare=False
     )
 
-    def with_rewards(self, rewards: Sequence[float]) -> "RLGroup":
-        rewards_list = list(rewards)
-        if len(rewards_list) != len(self.rollouts):
-            raise ValueError("rewards must match rollouts length")
-        return replace(self, rewards=rewards_list)
+    def __setattr__(self, name, value):
+        if name == "rewards" and value is not None:
+            rewards = list(value)
+            rollouts = self.__dict__.get("rollouts")
+            if rollouts is not None and len(rewards) != len(rollouts):
+                raise ValueError("rewards must match rollouts length")
+            value = rewards
+        object.__setattr__(self, name, value)
 
 
 @dataclass(frozen=True)

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -243,17 +243,21 @@ SaveCheckpointOutput = TypedDict(
     total=False,
 )
 
-@dataclass(frozen=True)
-class RolloutRequest:
-    skill: Skill
-    num_rollouts: int = 1
-    image: Optional[Union[Image.Image, EncodedImage]] = None
-    question: Optional[str] = None
-    object: Optional[str] = None
-    spatial_refs: Optional[List[SpatialRef]] = None
-    reasoning: bool = False
-    settings: Optional[SamplingSettings] = None
-    ground_truth: Optional[FinetuneGroundTruth] = None
+RolloutRequest = TypedDict(
+    "RolloutRequest",
+    {
+        "skill": Skill,
+        "num_rollouts": int,
+        "image": Optional[Union[Image.Image, EncodedImage]],
+        "question": Optional[str],
+        "object": Optional[str],
+        "spatial_refs": Optional[List[SpatialRef]],
+        "reasoning": bool,
+        "settings": Optional[SamplingSettings],
+        "ground_truth": Optional[FinetuneGroundTruth],
+    },
+    total=False,
+)
 
 
 RLGroup = TypedDict(

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -17,12 +17,6 @@ class Base64EncodedImage(EncodedImage):
 
 SamplingSettings = TypedDict(
     "SamplingSettings",
-    {"max_tokens": int},
-    total=False,
-)
-
-FinetuneSamplingSettings = TypedDict(
-    "FinetuneSamplingSettings",
     {
         "temperature": float,
         "top_p": float,
@@ -95,47 +89,6 @@ SegmentStreamChunk = TypedDict(
 
 SegmentStreamOutput = Generator[SegmentStreamChunk, None, None]
 
-QueryFinetuneRequest = TypedDict(
-    "QueryFinetuneRequest",
-    {
-        "skill": Literal["query"],
-        "question": str,
-        "image": Optional[Union[Image.Image, EncodedImage]],
-        "spatial_refs": List[SpatialRef],
-        "reasoning": bool,
-        "settings": FinetuneSamplingSettings,
-    },
-    total=False,
-)
-
-PointFinetuneRequest = TypedDict(
-    "PointFinetuneRequest",
-    {
-        "skill": Literal["point"],
-        "object": str,
-        "image": Union[Image.Image, EncodedImage],
-        "settings": FinetuneSamplingSettings,
-    },
-    total=False,
-)
-
-DetectFinetuneRequest = TypedDict(
-    "DetectFinetuneRequest",
-    {
-        "skill": Literal["detect"],
-        "object": str,
-        "image": Union[Image.Image, EncodedImage],
-        "settings": FinetuneSamplingSettings,
-    },
-    total=False,
-)
-
-FinetuneRequest = Union[
-    QueryFinetuneRequest,
-    PointFinetuneRequest,
-    DetectFinetuneRequest,
-]
-
 PointGroundTruth = TypedDict(
     "PointGroundTruth",
     {
@@ -171,8 +124,8 @@ DetectTarget = TypedDict("DetectTarget", {"boxes": List[Region]})
 
 SFTTarget = Union[QueryTarget, PointTarget, DetectTarget]
 
-RolloutOutput = TypedDict(
-    "RolloutOutput",
+_RawRolloutOutput = TypedDict(
+    "_RawRolloutOutput",
     {
         "answer": str,
         "reasoning": Optional[Reasoning],
@@ -182,12 +135,12 @@ RolloutOutput = TypedDict(
     total=False,
 )
 
-Rollout = TypedDict(
-    "Rollout",
+_RawRollout = TypedDict(
+    "_RawRollout",
     {
         "skill": Literal["query", "point", "detect"],
         "finish_reason": str,
-        "output": RolloutOutput,
+        "output": _RawRolloutOutput,
         "answer_tokens": List[int],
         "thinking_tokens": List[int],
         "has_answer_separator": bool,
@@ -196,6 +149,8 @@ Rollout = TypedDict(
     },
     total=False,
 )
+
+RolloutOutput = Union[QueryOutput, PointOutput, DetectOutput]
 
 TrainStepOutput = TypedDict(
     "TrainStepOutput",
@@ -257,18 +212,92 @@ CheckpointDownload = TypedDict(
 
 
 @dataclass(frozen=True)
-class RolloutSpec:
-    request: FinetuneRequest
+class RolloutGroup:
+    skill: Literal["query", "point", "detect"]
     num_rollouts: int = 1
+    image: Optional[Union[Image.Image, EncodedImage]] = None
+    question: Optional[str] = None
+    object: Optional[str] = None
+    spatial_refs: Optional[List[SpatialRef]] = None
+    reasoning: bool = False
+    settings: Optional[SamplingSettings] = None
     ground_truth: Optional[FinetuneGroundTruth] = None
+
+    @classmethod
+    def query(
+        cls,
+        question: str,
+        image: Optional[Union[Image.Image, EncodedImage]] = None,
+        *,
+        num_rollouts: int = 1,
+        settings: Optional[SamplingSettings] = None,
+        reasoning: bool = False,
+        spatial_refs: Optional[List[SpatialRef]] = None,
+    ) -> "RolloutGroup":
+        return cls(
+            skill="query",
+            num_rollouts=num_rollouts,
+            image=image,
+            question=question,
+            spatial_refs=spatial_refs,
+            reasoning=reasoning,
+            settings=settings,
+        )
+
+    @classmethod
+    def point(
+        cls,
+        image: Union[Image.Image, EncodedImage],
+        object: str,
+        *,
+        num_rollouts: int = 1,
+        settings: Optional[SamplingSettings] = None,
+        ground_truth: Optional[PointGroundTruth] = None,
+    ) -> "RolloutGroup":
+        return cls(
+            skill="point",
+            num_rollouts=num_rollouts,
+            image=image,
+            object=object,
+            settings=settings,
+            ground_truth=ground_truth,
+        )
+
+    @classmethod
+    def detect(
+        cls,
+        image: Union[Image.Image, EncodedImage],
+        object: str,
+        *,
+        num_rollouts: int = 1,
+        settings: Optional[SamplingSettings] = None,
+        ground_truth: Optional[DetectGroundTruth] = None,
+    ) -> "RolloutGroup":
+        return cls(
+            skill="detect",
+            num_rollouts=num_rollouts,
+            image=image,
+            object=object,
+            settings=settings,
+            ground_truth=ground_truth,
+        )
 
 
 @dataclass(frozen=True)
 class RLGroup:
-    request: FinetuneRequest
-    rollouts: List[Rollout]
+    skill: Literal["query", "point", "detect"]
+    rollouts: List[RolloutOutput]
+    image: Optional[Union[Image.Image, EncodedImage]] = None
+    question: Optional[str] = None
+    object: Optional[str] = None
+    spatial_refs: Optional[List[SpatialRef]] = None
+    reasoning: bool = False
+    settings: Optional[SamplingSettings] = None
     rewards: Optional[List[float]] = None
     _request_payload: Optional[dict] = field(default=None, repr=False, compare=False)
+    _rollouts_payload: Optional[List[_RawRollout]] = field(
+        default=None, repr=False, compare=False
+    )
 
     def with_rewards(self, rewards: Sequence[float]) -> "RLGroup":
         rewards_list = list(rewards)
@@ -279,8 +308,69 @@ class RLGroup:
 
 @dataclass(frozen=True)
 class SFTGroup:
-    request: FinetuneRequest
+    skill: Literal["query", "point", "detect"]
     targets: List[SFTTarget]
+    image: Optional[Union[Image.Image, EncodedImage]] = None
+    question: Optional[str] = None
+    object: Optional[str] = None
+    spatial_refs: Optional[List[SpatialRef]] = None
+    reasoning: bool = False
+    settings: Optional[SamplingSettings] = None
+
+    @classmethod
+    def query(
+        cls,
+        question: str,
+        targets: Sequence[QueryTarget],
+        image: Optional[Union[Image.Image, EncodedImage]] = None,
+        *,
+        settings: Optional[SamplingSettings] = None,
+        reasoning: bool = False,
+        spatial_refs: Optional[List[SpatialRef]] = None,
+    ) -> "SFTGroup":
+        return cls(
+            skill="query",
+            targets=list(targets),
+            image=image,
+            question=question,
+            spatial_refs=spatial_refs,
+            reasoning=reasoning,
+            settings=settings,
+        )
+
+    @classmethod
+    def point(
+        cls,
+        image: Union[Image.Image, EncodedImage],
+        object: str,
+        targets: Sequence[PointTarget],
+        *,
+        settings: Optional[SamplingSettings] = None,
+    ) -> "SFTGroup":
+        return cls(
+            skill="point",
+            targets=list(targets),
+            image=image,
+            object=object,
+            settings=settings,
+        )
+
+    @classmethod
+    def detect(
+        cls,
+        image: Union[Image.Image, EncodedImage],
+        object: str,
+        targets: Sequence[DetectTarget],
+        *,
+        settings: Optional[SamplingSettings] = None,
+    ) -> "SFTGroup":
+        return cls(
+            skill="detect",
+            targets=list(targets),
+            image=image,
+            object=object,
+            settings=settings,
+        )
 
 
 class VLM(ABC):

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -234,6 +234,23 @@ CheckpointListOutput = TypedDict(
     total=False,
 )
 
+OkResponse = TypedDict(
+    "OkResponse",
+    {
+        "ok": bool,
+    },
+    total=False,
+)
+
+SaveCheckpointOutput = TypedDict(
+    "SaveCheckpointOutput",
+    {
+        "ok": bool,
+        "checkpoint": CheckpointInfo,
+    },
+    total=False,
+)
+
 @dataclass(frozen=True)
 class RolloutRequest:
     skill: Skill

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -243,23 +243,6 @@ SaveCheckpointOutput = TypedDict(
     total=False,
 )
 
-RolloutRequest = TypedDict(
-    "RolloutRequest",
-    {
-        "skill": Skill,
-        "num_rollouts": int,
-        "image": Optional[Union[Image.Image, EncodedImage]],
-        "question": Optional[str],
-        "object": Optional[str],
-        "spatial_refs": Optional[List[SpatialRef]],
-        "reasoning": bool,
-        "settings": Optional[SamplingSettings],
-        "ground_truth": Optional[FinetuneGroundTruth],
-    },
-    total=False,
-)
-
-
 RLGroup = TypedDict(
     "RLGroup",
     {

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from PIL import Image
-from dataclasses import dataclass, field
-from typing import Generator, Generic, List, TypedDict, Union, Optional, Literal, Sequence, TypeVar
+from dataclasses import dataclass
+from typing import Generator, List, TypedDict, Union, Optional, Literal
 
 
 @dataclass
@@ -56,7 +56,7 @@ QueryOutput = TypedDict(
 )
 
 Region = TypedDict(
-    "Region", {"x_min": float, "y_min": float, "x_max": int, "y_max": float}
+    "Region", {"x_min": float, "y_min": float, "x_max": float, "y_max": float}
 )
 DetectOutput = TypedDict("DetectOutput", {"objects": List[Region]})
 
@@ -100,6 +100,7 @@ PointGroundTruth = TypedDict(
 DetectGroundTruth = TypedDict("DetectGroundTruth", {"boxes": List[Region]})
 
 FinetuneGroundTruth = Union[PointGroundTruth, DetectGroundTruth]
+Skill = Literal["query", "point", "detect"]
 
 QueryTarget = TypedDict(
     "QueryTarget",
@@ -123,8 +124,8 @@ DetectTarget = TypedDict("DetectTarget", {"boxes": List[Region]})
 
 SFTTarget = Union[QueryTarget, PointTarget, DetectTarget]
 
-_RawRolloutOutput = TypedDict(
-    "_RawRolloutOutput",
+RolloutOutput = TypedDict(
+    "RolloutOutput",
     {
         "answer": str,
         "reasoning": Optional[Reasoning],
@@ -134,12 +135,26 @@ _RawRolloutOutput = TypedDict(
     total=False,
 )
 
-_RawRollout = TypedDict(
-    "_RawRollout",
+SkillRequest = TypedDict(
+    "SkillRequest",
     {
-        "skill": Literal["query", "point", "detect"],
+        "skill": Skill,
+        "image_url": str,
+        "question": str,
+        "object": str,
+        "spatial_refs": List[SpatialRef],
+        "reasoning": bool,
+        "settings": SamplingSettings,
+    },
+    total=False,
+)
+
+Rollout = TypedDict(
+    "Rollout",
+    {
+        "skill": Skill,
         "finish_reason": str,
-        "output": _RawRolloutOutput,
+        "output": RolloutOutput,
         "answer_tokens": List[int],
         "thinking_tokens": List[int],
         "has_answer_separator": bool,
@@ -149,8 +164,15 @@ _RawRollout = TypedDict(
     total=False,
 )
 
-RolloutOutput = Union[QueryOutput, PointOutput, DetectOutput]
-RolloutOutputT = TypeVar("RolloutOutputT")
+RolloutsResponse = TypedDict(
+    "RolloutsResponse",
+    {
+        "request": SkillRequest,
+        "rollouts": List[Rollout],
+        "rewards": Optional[List[float]],
+    },
+    total=False,
+)
 
 TrainStepOutput = TypedDict(
     "TrainStepOutput",
@@ -213,8 +235,8 @@ CheckpointListOutput = TypedDict(
 )
 
 @dataclass(frozen=True)
-class RolloutGroup:
-    skill: Literal["query", "point", "detect"]
+class RolloutRequest:
+    skill: Skill
     num_rollouts: int = 1
     image: Optional[Union[Image.Image, EncodedImage]] = None
     question: Optional[str] = None
@@ -224,148 +246,27 @@ class RolloutGroup:
     settings: Optional[SamplingSettings] = None
     ground_truth: Optional[FinetuneGroundTruth] = None
 
-    @classmethod
-    def query(
-        cls,
-        question: str,
-        image: Optional[Union[Image.Image, EncodedImage]] = None,
-        *,
-        num_rollouts: int = 1,
-        settings: Optional[SamplingSettings] = None,
-        reasoning: bool = False,
-        spatial_refs: Optional[List[SpatialRef]] = None,
-    ) -> "RolloutGroup":
-        return cls(
-            skill="query",
-            num_rollouts=num_rollouts,
-            image=image,
-            question=question,
-            spatial_refs=spatial_refs,
-            reasoning=reasoning,
-            settings=settings,
-        )
 
-    @classmethod
-    def point(
-        cls,
-        image: Union[Image.Image, EncodedImage],
-        object: str,
-        *,
-        num_rollouts: int = 1,
-        settings: Optional[SamplingSettings] = None,
-        ground_truth: Optional[PointGroundTruth] = None,
-    ) -> "RolloutGroup":
-        return cls(
-            skill="point",
-            num_rollouts=num_rollouts,
-            image=image,
-            object=object,
-            settings=settings,
-            ground_truth=ground_truth,
-        )
+RLGroup = TypedDict(
+    "RLGroup",
+    {
+        "mode": Literal["rl"],
+        "request": SkillRequest,
+        "rollouts": List[Rollout],
+        "rewards": List[float],
+    },
+    total=False,
+)
 
-    @classmethod
-    def detect(
-        cls,
-        image: Union[Image.Image, EncodedImage],
-        object: str,
-        *,
-        num_rollouts: int = 1,
-        settings: Optional[SamplingSettings] = None,
-        ground_truth: Optional[DetectGroundTruth] = None,
-    ) -> "RolloutGroup":
-        return cls(
-            skill="detect",
-            num_rollouts=num_rollouts,
-            image=image,
-            object=object,
-            settings=settings,
-            ground_truth=ground_truth,
-        )
-
-
-@dataclass
-class RLGroup(Generic[RolloutOutputT]):
-    skill: Literal["query", "point", "detect"]
-    rollouts: List[RolloutOutputT]
-    image: Optional[Union[Image.Image, EncodedImage]] = None
-    question: Optional[str] = None
-    object: Optional[str] = None
-    spatial_refs: Optional[List[SpatialRef]] = None
-    reasoning: bool = False
-    settings: Optional[SamplingSettings] = None
-    rewards: Optional[List[float]] = None
-    _request_payload: Optional[dict] = field(default=None, repr=False, compare=False)
-    _rollouts_payload: Optional[List[_RawRollout]] = field(
-        default=None, repr=False, compare=False
-    )
-
-    def __setattr__(self, name, value):
-        if name == "rewards" and value is not None:
-            rewards = list(value)
-            rollouts = self.__dict__.get("rollouts")
-            if rollouts is not None and len(rewards) != len(rollouts):
-                raise ValueError("rewards must match rollouts length")
-            value = rewards
-        object.__setattr__(self, name, value)
-
-
-@dataclass(frozen=True)
-class SFTGroup:
-    skill: Literal["query", "point", "detect"]
-    targets: List[SFTTarget]
-    image: Optional[Union[Image.Image, EncodedImage]] = None
-    question: Optional[str] = None
-    object: Optional[str] = None
-    spatial_refs: Optional[List[SpatialRef]] = None
-    reasoning: bool = False
-
-    @classmethod
-    def query(
-        cls,
-        question: str,
-        targets: Sequence[QueryTarget],
-        image: Optional[Union[Image.Image, EncodedImage]] = None,
-        *,
-        reasoning: bool = False,
-        spatial_refs: Optional[List[SpatialRef]] = None,
-    ) -> "SFTGroup":
-        return cls(
-            skill="query",
-            targets=list(targets),
-            image=image,
-            question=question,
-            spatial_refs=spatial_refs,
-            reasoning=reasoning,
-        )
-
-    @classmethod
-    def point(
-        cls,
-        image: Union[Image.Image, EncodedImage],
-        object: str,
-        targets: Sequence[PointTarget],
-    ) -> "SFTGroup":
-        return cls(
-            skill="point",
-            targets=list(targets),
-            image=image,
-            object=object,
-        )
-
-    @classmethod
-    def detect(
-        cls,
-        image: Union[Image.Image, EncodedImage],
-        object: str,
-        targets: Sequence[DetectTarget],
-    ) -> "SFTGroup":
-        return cls(
-            skill="detect",
-            targets=list(targets),
-            image=image,
-            object=object,
-        )
+SFTGroup = TypedDict(
+    "SFTGroup",
+    {
+        "mode": Literal["sft"],
+        "request": SkillRequest,
+        "targets": List[SFTTarget],
+    },
+    total=False,
+)
 
 
 class VLM(ABC):

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -234,14 +234,6 @@ CheckpointListOutput = TypedDict(
     total=False,
 )
 
-OkResponse = TypedDict(
-    "OkResponse",
-    {
-        "ok": bool,
-    },
-    total=False,
-)
-
 SaveCheckpointOutput = TypedDict(
     "SaveCheckpointOutput",
     {

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Generator, List, Literal, Optional, Sequence, TypedDict, Union
+from typing import Generator, Generic, List, Literal, Optional, Sequence, TypeVar, TypedDict, Union
 
 from PIL import Image
 
@@ -151,6 +151,7 @@ _RawRollout = TypedDict(
 )
 
 RolloutOutput = Union[QueryOutput, PointOutput, DetectOutput]
+RolloutOutputT = TypeVar("RolloutOutputT")
 
 TrainStepOutput = TypedDict(
     "TrainStepOutput",
@@ -163,6 +164,16 @@ TrainStepOutput = TypedDict(
         "sft_loss": Optional[float],
         "reward_mean": Optional[float],
         "reward_std": Optional[float],
+    },
+    total=False,
+)
+
+MetricsLogOutput = TypedDict(
+    "MetricsLogOutput",
+    {
+        "ok": bool,
+        "step": int,
+        "logged_count": int,
     },
     total=False,
 )
@@ -275,9 +286,9 @@ class RolloutGroup:
 
 
 @dataclass
-class RLGroup:
+class RLGroup(Generic[RolloutOutputT]):
     skill: Literal["query", "point", "detect"]
-    rollouts: List[RolloutOutput]
+    rollouts: List[RolloutOutputT]
     image: Optional[Union[Image.Image, EncodedImage]] = None
     question: Optional[str] = None
     object: Optional[str] = None

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -202,15 +202,6 @@ CheckpointListOutput = TypedDict(
     total=False,
 )
 
-CheckpointDownload = TypedDict(
-    "CheckpointDownload",
-    {
-        "url": str,
-        "expires_in": int,
-    },
-)
-
-
 @dataclass(frozen=True)
 class RolloutGroup:
     skill: Literal["query", "point", "detect"]

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -247,7 +247,7 @@ SFTGroup = TypedDict(
     {
         "mode": Literal["sft"],
         "request": SkillRequest,
-        "targets": List[SFTTarget],
+        "target": SFTTarget,
     },
     total=False,
 )

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -90,10 +90,7 @@ SegmentStreamOutput = Generator[SegmentStreamChunk, None, None]
 
 PointGroundTruth = TypedDict(
     "PointGroundTruth",
-    {
-        "points": List[Point],
-        "boxes": List[Region],
-    },
+    {"points": List[Point], "boxes": List[Region]},
     total=False,
 )
 
@@ -104,19 +101,13 @@ Skill = Literal["query", "point", "detect"]
 
 QueryTarget = TypedDict(
     "QueryTarget",
-    {
-        "answer": str,
-        "reasoning": Reasoning,
-    },
+    {"answer": str, "reasoning": Reasoning},
     total=False,
 )
 
 PointTarget = TypedDict(
     "PointTarget",
-    {
-        "points": List[Point],
-        "boxes": List[Region],
-    },
+    {"points": List[Point], "boxes": List[Region]},
     total=False,
 )
 
@@ -236,10 +227,7 @@ CheckpointListOutput = TypedDict(
 
 SaveCheckpointOutput = TypedDict(
     "SaveCheckpointOutput",
-    {
-        "ok": bool,
-        "checkpoint": CheckpointInfo,
-    },
+    {"ok": bool, "checkpoint": CheckpointInfo},
     total=False,
 )
 

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field, replace
+from typing import Generator, List, Literal, Optional, Sequence, TypedDict, Union
+
 from PIL import Image
-from dataclasses import dataclass
-from typing import Generator, List, TypedDict, Union, Optional, Literal
 
 
 @dataclass
@@ -20,6 +21,17 @@ SamplingSettings = TypedDict(
     total=False,
 )
 
+FinetuneSamplingSettings = TypedDict(
+    "FinetuneSamplingSettings",
+    {
+        "temperature": float,
+        "top_p": float,
+        "max_tokens": int,
+        "max_objects": int,
+    },
+    total=False,
+)
+
 CaptionOutput = TypedDict(
     "CaptionOutput", {"caption": Union[str, Generator[str, None, None]]}
 )
@@ -29,25 +41,25 @@ ReasoningGrounding = TypedDict(
     {
         "start_idx": int,
         "end_idx": int,
-        "points": List[List[int]]  # List of [x, y] coordinate pairs
-    }
+        "points": List[List[int]],
+    },
 )
 
 Reasoning = TypedDict(
     "Reasoning",
     {
         "text": str,
-        "grounding": List[ReasoningGrounding]
-    }
+        "grounding": List[ReasoningGrounding],
+    },
 )
 
 QueryOutput = TypedDict(
-    "QueryOutput", 
+    "QueryOutput",
     {
-        "answer": Union[str, Generator[str, None, None]], 
-        "reasoning": Optional[Reasoning]
+        "answer": Union[str, Generator[str, None, None]],
+        "reasoning": Optional[Reasoning],
     },
-    total=False
+    total=False,
 )
 
 Region = TypedDict(
@@ -82,6 +94,193 @@ SegmentStreamChunk = TypedDict(
 )
 
 SegmentStreamOutput = Generator[SegmentStreamChunk, None, None]
+
+QueryFinetuneRequest = TypedDict(
+    "QueryFinetuneRequest",
+    {
+        "skill": Literal["query"],
+        "question": str,
+        "image": Optional[Union[Image.Image, EncodedImage]],
+        "spatial_refs": List[SpatialRef],
+        "reasoning": bool,
+        "settings": FinetuneSamplingSettings,
+    },
+    total=False,
+)
+
+PointFinetuneRequest = TypedDict(
+    "PointFinetuneRequest",
+    {
+        "skill": Literal["point"],
+        "object": str,
+        "image": Union[Image.Image, EncodedImage],
+        "settings": FinetuneSamplingSettings,
+    },
+    total=False,
+)
+
+DetectFinetuneRequest = TypedDict(
+    "DetectFinetuneRequest",
+    {
+        "skill": Literal["detect"],
+        "object": str,
+        "image": Union[Image.Image, EncodedImage],
+        "settings": FinetuneSamplingSettings,
+    },
+    total=False,
+)
+
+FinetuneRequest = Union[
+    QueryFinetuneRequest,
+    PointFinetuneRequest,
+    DetectFinetuneRequest,
+]
+
+PointGroundTruth = TypedDict(
+    "PointGroundTruth",
+    {
+        "points": List[Point],
+        "boxes": List[Region],
+    },
+    total=False,
+)
+
+DetectGroundTruth = TypedDict("DetectGroundTruth", {"boxes": List[Region]})
+
+FinetuneGroundTruth = Union[PointGroundTruth, DetectGroundTruth]
+
+QueryTarget = TypedDict(
+    "QueryTarget",
+    {
+        "answer": str,
+        "reasoning": Reasoning,
+    },
+    total=False,
+)
+
+PointTarget = TypedDict(
+    "PointTarget",
+    {
+        "points": List[Point],
+        "boxes": List[Region],
+    },
+    total=False,
+)
+
+DetectTarget = TypedDict("DetectTarget", {"boxes": List[Region]})
+
+SFTTarget = Union[QueryTarget, PointTarget, DetectTarget]
+
+RolloutOutput = TypedDict(
+    "RolloutOutput",
+    {
+        "answer": str,
+        "reasoning": Optional[Reasoning],
+        "points": List[Point],
+        "objects": List[Region],
+    },
+    total=False,
+)
+
+Rollout = TypedDict(
+    "Rollout",
+    {
+        "skill": Literal["query", "point", "detect"],
+        "finish_reason": str,
+        "output": RolloutOutput,
+        "answer_tokens": List[int],
+        "thinking_tokens": List[int],
+        "has_answer_separator": bool,
+        "coords": List[object],
+        "sizes": List[object],
+    },
+    total=False,
+)
+
+TrainStepOutput = TypedDict(
+    "TrainStepOutput",
+    {
+        "step": int,
+        "applied": bool,
+        "kl": Optional[float],
+        "router_kl": Optional[float],
+        "grad_norm": Optional[float],
+        "sft_loss": Optional[float],
+        "reward_mean": Optional[float],
+        "reward_std": Optional[float],
+    },
+    total=False,
+)
+
+FinetuneInfo = TypedDict(
+    "FinetuneInfo",
+    {
+        "finetune_id": str,
+        "name": str,
+        "rank": int,
+        "created_at_ms": int,
+        "updated_at_ms": int,
+    },
+    total=False,
+)
+
+CheckpointInfo = TypedDict(
+    "CheckpointInfo",
+    {
+        "checkpoint_id": str,
+        "finetune_id": str,
+        "step": int,
+        "expires_at_ms": Optional[int],
+        "created_at_ms": int,
+        "updated_at_ms": int,
+    },
+    total=False,
+)
+
+CheckpointListOutput = TypedDict(
+    "CheckpointListOutput",
+    {
+        "checkpoints": List[CheckpointInfo],
+        "next_cursor": Optional[str],
+        "has_more": bool,
+    },
+    total=False,
+)
+
+CheckpointDownload = TypedDict(
+    "CheckpointDownload",
+    {
+        "url": str,
+        "expires_in": int,
+    },
+)
+
+
+@dataclass(frozen=True)
+class RolloutSpec:
+    request: FinetuneRequest
+    num_rollouts: int = 1
+    ground_truth: Optional[FinetuneGroundTruth] = None
+
+
+@dataclass(frozen=True)
+class RLGroup:
+    request: FinetuneRequest
+    rollouts: List[Rollout]
+    rewards: Optional[List[float]] = None
+    _request_payload: Optional[dict] = field(default=None, repr=False, compare=False)
+
+    def with_rewards(self, rewards: Sequence[float]) -> "RLGroup":
+        rewards_list = list(rewards)
+        if len(rewards_list) != len(self.rollouts):
+            raise ValueError("rewards must match rollouts length")
+        return replace(self, rewards=rewards_list)
+
+
+@dataclass(frozen=True)
+class SFTGroup:
+    request: FinetuneRequest
+    targets: List[SFTTarget]
 
 
 class VLM(ABC):

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Generator, Generic, List, Literal, Optional, Sequence, TypeVar, TypedDict, Union
-
 from PIL import Image
+from dataclasses import dataclass, field
+from typing import Generator, Generic, List, TypedDict, Union, Optional, Literal, Sequence, TypeVar
 
 
 @dataclass
@@ -35,25 +34,25 @@ ReasoningGrounding = TypedDict(
     {
         "start_idx": int,
         "end_idx": int,
-        "points": List[List[int]],
-    },
+        "points": List[List[int]]  # List of [x, y] coordinate pairs
+    }
 )
 
 Reasoning = TypedDict(
     "Reasoning",
     {
         "text": str,
-        "grounding": List[ReasoningGrounding],
-    },
+        "grounding": List[ReasoningGrounding]
+    }
 )
 
 QueryOutput = TypedDict(
-    "QueryOutput",
+    "QueryOutput", 
     {
-        "answer": Union[str, Generator[str, None, None]],
-        "reasoning": Optional[Reasoning],
+        "answer": Union[str, Generator[str, None, None]], 
+        "reasoning": Optional[Reasoning]
     },
-    total=False,
+    total=False
 )
 
 Region = TypedDict(

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -309,7 +309,6 @@ class SFTGroup:
     object: Optional[str] = None
     spatial_refs: Optional[List[SpatialRef]] = None
     reasoning: bool = False
-    settings: Optional[SamplingSettings] = None
 
     @classmethod
     def query(
@@ -318,7 +317,6 @@ class SFTGroup:
         targets: Sequence[QueryTarget],
         image: Optional[Union[Image.Image, EncodedImage]] = None,
         *,
-        settings: Optional[SamplingSettings] = None,
         reasoning: bool = False,
         spatial_refs: Optional[List[SpatialRef]] = None,
     ) -> "SFTGroup":
@@ -329,7 +327,6 @@ class SFTGroup:
             question=question,
             spatial_refs=spatial_refs,
             reasoning=reasoning,
-            settings=settings,
         )
 
     @classmethod
@@ -338,15 +335,12 @@ class SFTGroup:
         image: Union[Image.Image, EncodedImage],
         object: str,
         targets: Sequence[PointTarget],
-        *,
-        settings: Optional[SamplingSettings] = None,
     ) -> "SFTGroup":
         return cls(
             skill="point",
             targets=list(targets),
             image=image,
             object=object,
-            settings=settings,
         )
 
     @classmethod
@@ -355,15 +349,12 @@ class SFTGroup:
         image: Union[Image.Image, EncodedImage],
         object: str,
         targets: Sequence[DetectTarget],
-        *,
-        settings: Optional[SamplingSettings] = None,
     ) -> "SFTGroup":
         return cls(
             skill="detect",
             targets=list(targets),
             image=image,
             object=object,
-            settings=settings,
         )
 
 

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -237,6 +237,22 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.client.batch_rollouts([], max_concurrency=0)
 
+    def test_sft_group_builds_http_shaped_group(self):
+        group = self.client.sft_group(
+            skill="query",
+            image=self.image,
+            question="What is happening?",
+            targets=[{"answer": "People are smiling for a photo."}],
+            reasoning=True,
+        )
+
+        self.assertEqual(group["mode"], "sft")
+        self.assertEqual(group["request"]["skill"], "query")
+        self.assertEqual(group["request"]["question"], "What is happening?")
+        self.assertTrue(group["request"]["reasoning"])
+        self.assertEqual(group["targets"], [{"answer": "People are smiling for a photo."}])
+        self.assertTrue(group["request"]["image_url"].startswith("data:image/jpeg;base64,"))
+
     def test_train_step_builds_mixed_rl_and_sft_payload(self):
         raw_rollout = _raw_rollout("query", {"answer": "A sign"})
         rl_group: RLGroup = {
@@ -249,15 +265,12 @@ class FinetuneTests(unittest.TestCase):
             "rollouts": [raw_rollout],
             "rewards": [1.0],
         }
-        sft_group: SFTGroup = {
-            "mode": "sft",
-            "request": {
-                "skill": "query",
-                "question": "What country is this?",
-                "image_url": "data:image/jpeg;base64,abc",
-            },
-            "targets": [{"answer": "United States"}],
-        }
+        sft_group = self.client.sft_group(
+            skill="query",
+            image=self.image,
+            question="What country is this?",
+            targets=[{"answer": "United States"}],
+        )
 
         with mock.patch.object(
             self.client, "_request_json", return_value={"step": 1, "applied": True}

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -10,7 +10,7 @@ import moondream as md
 from PIL import Image
 
 from moondream.finetune import Finetune, FinetuneAPIError, ft
-from moondream.types import EncodedImage, RLGroup, RolloutRequest, SFTGroup
+from moondream.types import EncodedImage, RLGroup, SFTGroup
 
 
 class _FakeResponse:
@@ -82,10 +82,8 @@ class FinetuneTests(unittest.TestCase):
     def test_package_exposes_helper_types_under_md_types(self):
         self.assertTrue(hasattr(md, "ft"))
         self.assertTrue(hasattr(md, "types"))
-        self.assertIs(md.types.RolloutRequest, RolloutRequest)
         self.assertIs(md.types.RLGroup, RLGroup)
         self.assertIs(md.types.SFTGroup, SFTGroup)
-        self.assertFalse(hasattr(md, "RolloutRequest"))
         self.assertFalse(hasattr(md, "RLGroup"))
         self.assertFalse(hasattr(md, "SFTGroup"))
 
@@ -144,17 +142,15 @@ class FinetuneTests(unittest.TestCase):
             "rollouts": [_raw_rollout("query", {"answer": "People are socializing."})],
         }
 
-        request = RolloutRequest(
-            skill="query",
-            image=self.image,
-            question="What is happening?",
-            num_rollouts=2,
-            reasoning=True,
-            settings={"temperature": 1.0, "top_p": 1.0, "max_tokens": 8},
-        )
-
         with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
-            result = self.client.rollouts(request)
+            result = self.client.rollouts(
+                "query",
+                image=self.image,
+                question="What is happening?",
+                num_rollouts=2,
+                reasoning=True,
+                settings={"temperature": 1.0, "top_p": 1.0, "max_tokens": 8},
+            )
 
         self.assertEqual(result, response)
         payload = mocked.call_args.kwargs["payload"]
@@ -166,37 +162,33 @@ class FinetuneTests(unittest.TestCase):
         self.assertTrue(payload["request"]["reasoning"])
 
     def test_rollouts_pass_settings_through(self):
-        request = RolloutRequest(
-            skill="query",
-            question="What is here?",
-            image=self.image,
-            settings={"max_objects": 2},
-        )
-
         with mock.patch.object(
             self.client,
             "_request_json",
             return_value={"request": {"skill": "query"}, "rollouts": []},
         ) as mocked:
-            self.client.rollouts(request)
+            self.client.rollouts(
+                "query",
+                question="What is here?",
+                image=self.image,
+                settings={"max_objects": 2},
+            )
 
         payload = mocked.call_args.kwargs["payload"]
         self.assertEqual(payload["request"]["settings"]["max_objects"], 2)
 
     def test_rollouts_pass_ground_truth_through(self):
-        request = RolloutRequest(
-            skill="detect",
-            image=self.image,
-            object="vehicles",
-            ground_truth={"boxes": []},
-        )
-
         with mock.patch.object(
             self.client,
             "_request_json",
             return_value={"request": {"skill": "detect"}, "rollouts": []},
         ) as mocked:
-            self.client.rollouts(request)
+            self.client.rollouts(
+                "detect",
+                image=self.image,
+                object="vehicles",
+                ground_truth={"boxes": []},
+            )
 
         payload = mocked.call_args.kwargs["payload"]
         self.assertEqual(payload["ground_truth"], {"boxes": []})
@@ -206,24 +198,23 @@ class FinetuneTests(unittest.TestCase):
             pass
 
         with self.assertRaises(ValueError):
-            self.client.rollouts(
-                RolloutRequest(skill="detect", image=FakeEncodedImage(), object="vehicles")
-            )
+            self.client.rollouts("detect", image=FakeEncodedImage(), object="vehicles")
 
     def test_rollout_stream_yields_context_response_pairs(self):
-        def fake_rollouts(request):
+        def fake_rollouts(skill, **kwargs):
+            question = kwargs.get("question", "")
             return {
                 "request": {
-                    "skill": request.skill,
-                    "question": request.question,
+                    "skill": skill,
+                    "question": question,
                 },
-                "rollouts": [_raw_rollout(request.skill, {"answer": request.question})],
+                "rollouts": [_raw_rollout(skill, {"answer": question})],
                 "rewards": [0.5],
             }
 
         items = [
-            ({"label": "rock"}, RolloutRequest(skill="query", question="q0")),
-            ({"label": "paper"}, RolloutRequest(skill="query", question="q1")),
+            ({"label": "rock"}, {"skill": "query", "question": "q0"}),
+            ({"label": "paper"}, {"skill": "query", "question": "q1"}),
         ]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
@@ -378,11 +369,9 @@ class FinetuneTests(unittest.TestCase):
             side_effect=[rollout_response, {"step": 4, "applied": True}],
         ) as mocked:
             response = self.client.rollouts(
-                RolloutRequest(
-                    skill="query",
-                    image=self.image,
-                    question="What is happening?",
-                )
+                "query",
+                image=self.image,
+                question="What is happening?",
             )
             group: RLGroup = {
                 "mode": "rl",
@@ -490,7 +479,7 @@ class FinetuneTests(unittest.TestCase):
         active = {"count": 0, "max": 0}
         lock = threading.Lock()
 
-        def fake_rollouts(request):
+        def fake_rollouts(skill, **kwargs):
             with lock:
                 active["count"] += 1
                 active["max"] = max(active["max"], active["count"])
@@ -498,11 +487,11 @@ class FinetuneTests(unittest.TestCase):
             with lock:
                 active["count"] -= 1
             return {
-                "request": {"skill": request.skill, "question": request.question},
+                "request": {"skill": skill, "question": kwargs.get("question", "")},
                 "rollouts": [],
             }
 
-        items = [(i, RolloutRequest(skill="query", question=f"q{i}")) for i in range(5)]
+        items = [(i, {"skill": "query", "question": f"q{i}"}) for i in range(5)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
             results = list(self.client.rollout_stream(items, max_concurrency=2))
@@ -513,17 +502,17 @@ class FinetuneTests(unittest.TestCase):
     def test_rollout_stream_stops_on_error(self):
         call_count = [0]
 
-        def fake_rollouts(request):
+        def fake_rollouts(skill, **kwargs):
             call_count[0] += 1
             if call_count[0] == 2:
                 raise FinetuneAPIError("boom")
             time.sleep(0.02)
             return {
-                "request": {"skill": request.skill, "question": request.question},
+                "request": {"skill": skill, "question": kwargs.get("question", "")},
                 "rollouts": [],
             }
 
-        items = [(i, RolloutRequest(skill="query", question=f"q{i}")) for i in range(10)]
+        items = [(i, {"skill": "query", "question": f"q{i}"}) for i in range(10)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
             with self.assertRaises(FinetuneAPIError):
@@ -535,18 +524,19 @@ class FinetuneTests(unittest.TestCase):
         started = []
         lock = threading.Lock()
 
-        def fake_rollouts(request):
+        def fake_rollouts(skill, **kwargs):
+            question = kwargs.get("question", "")
             with lock:
-                started.append(request.question)
-            if request.question == "q1":
+                started.append(question)
+            if question == "q1":
                 raise FinetuneAPIError("boom")
             time.sleep(0.1)
             return {
-                "request": {"skill": request.skill, "question": request.question},
+                "request": {"skill": skill, "question": question},
                 "rollouts": [],
             }
 
-        items = [(i, RolloutRequest(skill="query", question=f"q{i}")) for i in range(20)]
+        items = [(i, {"skill": "query", "question": f"q{i}"}) for i in range(20)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
             with self.assertRaises(FinetuneAPIError):
@@ -559,13 +549,13 @@ class FinetuneTests(unittest.TestCase):
 
     def test_rollout_stream_surfaces_iterator_error(self):
         def bad_iterator():
-            yield (None, RolloutRequest(skill="query", question="q0"))
+            yield (None, {"skill": "query", "question": "q0"})
             raise RuntimeError("dataset failed")
 
-        def fake_rollouts(request):
+        def fake_rollouts(skill, **kwargs):
             time.sleep(0.02)
             return {
-                "request": {"skill": request.skill, "question": request.question},
+                "request": {"skill": skill, "question": kwargs.get("question", "")},
                 "rollouts": [],
             }
 

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -63,10 +63,6 @@ class FinetuneTests(unittest.TestCase):
             finetune_id="ft_123",
             name="demo-ft",
             rank=8,
-            max_retries=2,
-            retry_base_delay=0.01,
-            retry_max_delay=0.01,
-            timeout=0.01,
         )
 
     def test_ft_validates_constructor_inputs(self):
@@ -76,8 +72,6 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             ft(api_key="x", name="demo", finetune_id="ft_123")
 
-        with self.assertRaises(ValueError):
-            ft(api_key="x", name="demo", rank=8, max_retries=-1)
 
     def test_package_exposes_helper_types_under_md_types(self):
         self.assertTrue(hasattr(md, "ft"))
@@ -408,7 +402,6 @@ class FinetuneTests(unittest.TestCase):
                 "groups": [group],
                 "lr": 0.002,
             },
-            max_retries=0,
         )
 
     def test_request_json_retries_timeout_then_succeeds(self):
@@ -451,25 +444,6 @@ class FinetuneTests(unittest.TestCase):
                 result = self.client._request_json("POST", "/rollouts", payload={"x": 1})
 
         self.assertEqual(result, {"ok": True})
-
-    def test_train_step_does_not_retry_timeout(self):
-        group: RLGroup = {
-            "mode": "rl",
-            "request": {"skill": "query", "question": "What is this?"},
-            "rollouts": [_raw_rollout("query", {"answer": "A photo"})],
-            "rewards": [1.0],
-        }
-
-        with mock.patch(
-            "urllib.request.urlopen",
-            side_effect=urllib.error.URLError(socket.timeout("timed out")),
-        ) as mocked:
-            with mock.patch("time.sleep") as mocked_sleep:
-                with self.assertRaises(urllib.error.URLError):
-                    self.client.train_step([group])
-
-        self.assertEqual(mocked.call_count, 1)
-        mocked_sleep.assert_not_called()
 
     def test_rollout_stream_respects_concurrency_cap(self):
         active = {"count": 0, "max": 0}

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -237,8 +237,8 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.client.batch_rollouts([], max_concurrency=0)
 
-    def test_sft_group_builds_http_shaped_group(self):
-        group = self.client.sft_group(
+    def test_build_sft_group_builds_http_shaped_group(self):
+        group = self.client.build_sft_group(
             skill="query",
             image=self.image,
             question="What is happening?",
@@ -265,7 +265,7 @@ class FinetuneTests(unittest.TestCase):
             "rollouts": [raw_rollout],
             "rewards": [1.0],
         }
-        sft_group = self.client.sft_group(
+        sft_group = self.client.build_sft_group(
             skill="query",
             image=self.image,
             question="What country is this?",

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -166,6 +166,43 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["request"]["skill"], "detect")
         self.assertTrue(payload["request"]["image_url"].startswith("data:image/jpeg;base64,"))
 
+    def test_detect_rollouts_deep_copy_public_outputs(self):
+        response = {
+            "request": {
+                "skill": "detect",
+                "object": "vehicles",
+                "image_url": "data:image/jpeg;base64,abc",
+            },
+            "rollouts": [
+                _raw_rollout(
+                    "detect",
+                    {
+                        "objects": [
+                            {
+                                "x_min": 0.1,
+                                "y_min": 0.2,
+                                "x_max": 0.3,
+                                "y_max": 0.4,
+                            }
+                        ]
+                    },
+                )
+            ],
+        }
+
+        with mock.patch.object(self.client, "_request_json", return_value=response):
+            rl_group = self.client.detect_rollouts(
+                self.image,
+                "vehicles",
+            )
+
+        rl_group.rollouts[0]["objects"].append(
+            {"x_min": 0.5, "y_min": 0.6, "x_max": 0.7, "y_max": 0.8}
+        )
+
+        self.assertEqual(len(rl_group.rollouts[0]["objects"]), 2)
+        self.assertEqual(len(rl_group._rollouts_payload[0]["output"]["objects"]), 1)
+
     def test_query_rollouts_return_flat_model_outputs(self):
         response = {
             "request": {

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -182,21 +182,31 @@ class FinetuneTests(unittest.TestCase):
         self.assertNotIn("output", rl_group.rollouts[0])
         self.assertEqual(rl_group.question, "What is happening?")
 
-    def test_query_rollouts_reject_invalid_settings(self):
-        with self.assertRaises(ValueError):
+    def test_query_rollouts_pass_settings_through(self):
+        response = {"request": {"skill": "query", "question": "What is here?"}, "rollouts": []}
+
+        with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
             self.client.query_rollouts(
                 image=self.image,
                 question="What is here?",
                 settings={"max_objects": 2},
             )
 
-    def test_detect_rollouts_reject_invalid_settings(self):
-        with self.assertRaises(ValueError):
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["request"]["settings"]["max_objects"], 2)
+
+    def test_detect_rollouts_pass_settings_through(self):
+        response = {"request": {"skill": "detect", "object": "vehicles"}, "rollouts": []}
+
+        with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
             self.client.detect_rollouts(
                 self.image,
                 "vehicles",
                 settings={"max_tokens": 16},
             )
+
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["request"]["settings"]["max_tokens"], 16)
 
     def test_rollouts_reject_unknown_encoded_image(self):
         class FakeEncodedImage(EncodedImage):

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -210,7 +210,7 @@ class FinetuneTests(unittest.TestCase):
                 RolloutRequest(skill="detect", image=FakeEncodedImage(), object="vehicles")
             )
 
-    def test_rollout_stream_yields_responses(self):
+    def test_rollout_stream_yields_context_response_pairs(self):
         def fake_rollouts(request):
             return {
                 "request": {
@@ -221,17 +221,20 @@ class FinetuneTests(unittest.TestCase):
                 "rewards": [0.5],
             }
 
-        requests = [
-            RolloutRequest(skill="query", question="q0"),
-            RolloutRequest(skill="query", question="q1"),
+        items = [
+            ({"label": "rock"}, RolloutRequest(skill="query", question="q0")),
+            ({"label": "paper"}, RolloutRequest(skill="query", question="q1")),
         ]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
-            responses = list(self.client.rollout_stream(requests, max_concurrency=2))
+            results = list(self.client.rollout_stream(items, max_concurrency=2))
 
-        self.assertEqual(len(responses), 2)
-        questions = {r["request"]["question"] for r in responses}
-        self.assertEqual(questions, {"q0", "q1"})
+        self.assertEqual(len(results), 2)
+        contexts = {r[0]["label"] for r in results}
+        self.assertEqual(contexts, {"rock", "paper"})
+        for context, response in results:
+            self.assertIn("request", response)
+            self.assertIn("rollouts", response)
 
     def test_rollout_stream_validates_params(self):
         with self.assertRaises(ValueError):
@@ -499,12 +502,12 @@ class FinetuneTests(unittest.TestCase):
                 "rollouts": [],
             }
 
-        requests = [RolloutRequest(skill="query", question=f"q{i}") for i in range(5)]
+        items = [(i, RolloutRequest(skill="query", question=f"q{i}")) for i in range(5)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
-            responses = list(self.client.rollout_stream(requests, max_concurrency=2))
+            results = list(self.client.rollout_stream(items, max_concurrency=2))
 
-        self.assertEqual(len(responses), 5)
+        self.assertEqual(len(results), 5)
         self.assertLessEqual(active["max"], 2)
 
     def test_rollout_stream_stops_on_error(self):
@@ -520,11 +523,11 @@ class FinetuneTests(unittest.TestCase):
                 "rollouts": [],
             }
 
-        requests = [RolloutRequest(skill="query", question=f"q{i}") for i in range(10)]
+        items = [(i, RolloutRequest(skill="query", question=f"q{i}")) for i in range(10)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
             with self.assertRaises(FinetuneAPIError):
-                list(self.client.rollout_stream(requests, max_concurrency=2))
+                list(self.client.rollout_stream(items, max_concurrency=2))
 
     def test_rollout_stream_stops_before_extra_requests_on_error(self):
         """stop.set() must happen before blocking on the queue so other
@@ -543,12 +546,12 @@ class FinetuneTests(unittest.TestCase):
                 "rollouts": [],
             }
 
-        requests = [RolloutRequest(skill="query", question=f"q{i}") for i in range(20)]
+        items = [(i, RolloutRequest(skill="query", question=f"q{i}")) for i in range(20)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
             with self.assertRaises(FinetuneAPIError):
                 list(self.client.rollout_stream(
-                    requests, max_concurrency=2, buffer_size=1,
+                    items, max_concurrency=2, buffer_size=1,
                 ))
 
         # Workers should not have started many requests beyond the failure
@@ -556,7 +559,7 @@ class FinetuneTests(unittest.TestCase):
 
     def test_rollout_stream_surfaces_iterator_error(self):
         def bad_iterator():
-            yield RolloutRequest(skill="query", question="q0")
+            yield (None, RolloutRequest(skill="query", question="q0"))
             raise RuntimeError("dataset failed")
 
         def fake_rollouts(request):
@@ -608,7 +611,7 @@ class FinetuneTests(unittest.TestCase):
             "/finetunes/ft_123/checkpoints/save",
         )
 
-    def test_delete_returns_raw_response(self):
+    def test_delete_returns_none(self):
         with mock.patch.object(
             self.client,
             "_request_json",
@@ -616,10 +619,10 @@ class FinetuneTests(unittest.TestCase):
         ) as mocked:
             result = self.client.delete()
 
-        self.assertEqual(result, {"ok": True})
+        self.assertIsNone(result)
         mocked.assert_called_once_with("DELETE", "/finetunes/ft_123")
 
-    def test_delete_checkpoint_returns_raw_response(self):
+    def test_delete_checkpoint_returns_none(self):
         with mock.patch.object(
             self.client,
             "_request_json",
@@ -627,7 +630,7 @@ class FinetuneTests(unittest.TestCase):
         ) as mocked:
             result = self.client.delete_checkpoint(7)
 
-        self.assertEqual(result, {"ok": True})
+        self.assertIsNone(result)
         mocked.assert_called_once_with(
             "DELETE",
             "/finetunes/ft_123/checkpoints/7",

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -227,21 +227,26 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             list(self.client.rollout_stream([], buffer_size=0))
 
-    def test_build_sft_group_builds_http_shaped_group(self):
-        group = self.client.build_sft_group(
-            skill="query",
-            image=self.image,
-            question="What is happening?",
-            target={"answer": "People are smiling for a photo."},
-            reasoning=True,
-        )
+    def test_train_step_encodes_images_in_groups(self):
+        sft_group: SFTGroup = {
+            "mode": "sft",
+            "request": {
+                "skill": "query",
+                "question": "What is happening?",
+                "image": self.image,
+            },
+            "target": {"answer": "People are smiling."},
+        }
 
-        self.assertEqual(group["mode"], "sft")
-        self.assertEqual(group["request"]["skill"], "query")
-        self.assertEqual(group["request"]["question"], "What is happening?")
-        self.assertTrue(group["request"]["reasoning"])
-        self.assertEqual(group["target"], {"answer": "People are smiling for a photo."})
-        self.assertTrue(group["request"]["image_url"].startswith("data:image/jpeg;base64,"))
+        with mock.patch.object(
+            self.client, "_request_json", return_value={"step": 1, "applied": True}
+        ) as mocked:
+            self.client.train_step([sft_group])
+
+        payload = mocked.call_args.kwargs["payload"]
+        request = payload["groups"][0]["request"]
+        self.assertNotIn("image", request)
+        self.assertTrue(request["image_url"].startswith("data:image/jpeg;base64,"))
 
     def test_train_step_builds_mixed_rl_and_sft_payload(self):
         raw_rollout = _raw_rollout("query", {"answer": "A sign"})
@@ -255,12 +260,15 @@ class FinetuneTests(unittest.TestCase):
             "rollouts": [raw_rollout],
             "rewards": [1.0],
         }
-        sft_group = self.client.build_sft_group(
-            skill="query",
-            image=self.image,
-            question="What country is this?",
-            target={"answer": "United States"},
-        )
+        sft_group: SFTGroup = {
+            "mode": "sft",
+            "request": {
+                "skill": "query",
+                "question": "What country is this?",
+                "image": self.image,
+            },
+            "target": {"answer": "United States"},
+        }
 
         with mock.patch.object(
             self.client, "_request_json", return_value={"step": 1, "applied": True}
@@ -276,6 +284,7 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["groups"][0]["rewards"], [1.0])
         self.assertEqual(payload["groups"][1]["mode"], "sft")
         self.assertEqual(payload["groups"][1]["target"], {"answer": "United States"})
+        self.assertTrue(payload["groups"][1]["request"]["image_url"].startswith("data:image/jpeg;base64,"))
 
     def test_train_step_returns_raw_response(self):
         rl_group: RLGroup = {

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -387,6 +387,26 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.client.train_step([rl_group])
 
+    def test_train_step_rejects_mutated_rollouts_after_generation(self):
+        raw_rollouts = [
+            _raw_rollout("query", {"answer": "A photo"}),
+            _raw_rollout("query", {"answer": "A drawing"}),
+        ]
+        rl_group = RLGroup(
+            skill="query",
+            question="What is this?",
+            rollouts=[{"answer": "A photo"}, {"answer": "A drawing"}],
+            _request_payload={"skill": "query", "question": "What is this?"},
+            _rollouts_payload=raw_rollouts,
+        )
+        rl_group.rollouts = rl_group.rollouts[:1]
+        rl_group.rewards = [1.0]
+
+        with self.assertRaisesRegex(
+            ValueError, "RLGroup rollouts must not be mutated"
+        ):
+            self.client.train_step([rl_group])
+
     def test_detect_rollouts_allow_empty_boxes_ground_truth(self):
         response = {
             "request": {

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -1,0 +1,578 @@
+import json
+import socket
+import threading
+import unittest
+import urllib.error
+from unittest import mock
+
+from PIL import Image
+
+import moondream as md
+from moondream.finetune import Finetune, FinetuneAPIError, ft
+from moondream.types import EncodedImage, RLGroup, RolloutSpec, SFTGroup
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _http_error(status, body, headers=None):
+    if isinstance(body, dict):
+        body = json.dumps(body).encode("utf-8")
+    return urllib.error.HTTPError(
+        url="https://example.test",
+        code=status,
+        msg="error",
+        hdrs=headers or {},
+        fp=mock.Mock(read=mock.Mock(return_value=body)),
+    )
+
+
+class FinetuneTests(unittest.TestCase):
+    def setUp(self):
+        self.image = Image.new("RGB", (4, 4), color="white")
+        self.client = Finetune(
+            api_key="test-key",
+            endpoint="https://api.example.test/v1/tuning",
+            finetune_id="ft_123",
+            name="demo-ft",
+            rank=8,
+            max_retries=2,
+            retry_base_delay=0.01,
+            retry_max_delay=0.01,
+            timeout=0.01,
+        )
+
+    def test_ft_validates_constructor_inputs(self):
+        with self.assertRaises(ValueError):
+            ft(api_key="x")
+
+        with self.assertRaises(ValueError):
+            ft(api_key="x", name="demo", finetune_id="ft_123")
+
+        with self.assertRaises(ValueError):
+            ft(api_key="x", name="bad name", rank=8)
+
+        with self.assertRaises(ValueError):
+            ft(api_key="x", name="demo", rank=12)
+
+        with self.assertRaises(ValueError):
+            ft(api_key="x", name="demo", rank=8, max_retries=-1)
+
+    def test_ft_binds_existing_finetune(self):
+        response = {
+            "finetune": {
+                "finetune_id": "ft_456",
+                "name": "existing-ft",
+                "rank": 16,
+            }
+        }
+
+        with mock.patch.object(Finetune, "_request_json", return_value=response) as mocked:
+            client = ft(
+                api_key="x",
+                finetune_id="ft_456",
+                endpoint="https://api.example.test/v1/tuning",
+            )
+
+        self.assertEqual(client.finetune_id, "ft_456")
+        self.assertEqual(client.name, "existing-ft")
+        self.assertEqual(client.rank, 16)
+        mocked.assert_called_once_with("GET", "/finetunes/ft_456")
+
+    def test_ft_creates_new_finetune(self):
+        with mock.patch.object(
+            Finetune,
+            "_request_json",
+            return_value={"finetune_id": "ft_789"},
+        ) as mocked:
+            client = ft(
+                api_key="x",
+                name="new-ft",
+                rank=8,
+                endpoint="https://api.example.test/v1/tuning",
+            )
+
+        self.assertEqual(client.finetune_id, "ft_789")
+        self.assertEqual(client.name, "new-ft")
+        self.assertEqual(client.rank, 8)
+        mocked.assert_called_once_with(
+            "POST",
+            "/finetunes",
+            payload={"name": "new-ft", "rank": 8},
+        )
+
+    def test_rollouts_serializes_request_and_returns_rl_group(self):
+        request = {
+            "skill": "detect",
+            "object": "vehicles",
+            "image": self.image,
+            "settings": {"temperature": 1.0, "top_p": 1.0, "max_objects": 5},
+        }
+        response = {
+            "request": {
+                "skill": "detect",
+                "object": "vehicles",
+                "image_url": "data:image/jpeg;base64,abc",
+            },
+            "rollouts": [
+                {
+                    "skill": "detect",
+                    "finish_reason": "stop",
+                    "output": {"objects": []},
+                    "answer_tokens": [],
+                    "thinking_tokens": [],
+                    "has_answer_separator": False,
+                    "coords": [],
+                    "sizes": [],
+                }
+            ],
+            "rewards": None,
+        }
+
+        with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
+            rl_group = self.client.rollouts(request, num_rollouts=2)
+
+        self.assertIsInstance(rl_group, RLGroup)
+        self.assertEqual(rl_group.request, request)
+        self.assertEqual(len(rl_group.rollouts), 1)
+
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["finetune_id"], "ft_123")
+        self.assertEqual(payload["num_rollouts"], 2)
+        self.assertEqual(payload["request"]["skill"], "detect")
+        self.assertTrue(payload["request"]["image_url"].startswith("data:image/jpeg;base64,"))
+
+    def test_rollouts_rejects_query_ground_truth(self):
+        with self.assertRaises(ValueError):
+            self.client.rollouts(
+                {"skill": "query", "question": "What is here?", "image": self.image},
+                ground_truth={"boxes": []},
+            )
+
+    def test_rollouts_reject_unknown_encoded_image(self):
+        class FakeEncodedImage(EncodedImage):
+            pass
+
+        with self.assertRaises(ValueError):
+            self.client.rollouts(
+                {
+                    "skill": "detect",
+                    "object": "vehicles",
+                    "image": FakeEncodedImage(),
+                }
+            )
+
+    def test_rlgroup_with_rewards_validates_length(self):
+        rl_group = RLGroup(
+            request={"skill": "query", "question": "hi"},
+            rollouts=[
+                {
+                    "skill": "query",
+                    "finish_reason": "stop",
+                    "output": {"answer": "hello"},
+                    "answer_tokens": [],
+                    "thinking_tokens": [],
+                    "has_answer_separator": False,
+                    "coords": [],
+                    "sizes": [],
+                }
+            ],
+        )
+
+        with self.assertRaises(ValueError):
+            rl_group.with_rewards([1.0, 0.0])
+
+    def test_train_step_builds_mixed_rl_and_sft_payload(self):
+        rl_group = RLGroup(
+            request={"skill": "query", "question": "What is this?", "image": self.image},
+            rollouts=[
+                {
+                    "skill": "query",
+                    "finish_reason": "stop",
+                    "output": {"answer": "A sign"},
+                    "answer_tokens": [1],
+                    "thinking_tokens": [],
+                    "has_answer_separator": False,
+                    "coords": [],
+                    "sizes": [],
+                }
+            ],
+            rewards=[1.0],
+            _request_payload={
+                "skill": "query",
+                "question": "What is this?",
+                "image_url": "data:image/jpeg;base64,abc",
+            },
+        )
+        sft_group = SFTGroup(
+            request={
+                "skill": "query",
+                "question": "What country is this?",
+                "image": self.image,
+                "reasoning": False,
+                "settings": {"temperature": 0.0, "top_p": 1.0, "max_tokens": 16},
+            },
+            targets=[{"answer": "United States"}],
+        )
+
+        with mock.patch.object(
+            self.client, "_request_json", return_value={"step": 1, "applied": True}
+        ) as mocked:
+            result = self.client.train_step([rl_group, sft_group], lr=0.003)
+
+        self.assertEqual(result["step"], 1)
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["finetune_id"], "ft_123")
+        self.assertEqual(payload["lr"], 0.003)
+        self.assertEqual(payload["groups"][0]["mode"], "rl")
+        self.assertEqual(payload["groups"][0]["rewards"], [1.0])
+        self.assertEqual(payload["groups"][1]["mode"], "sft")
+        self.assertEqual(payload["groups"][1]["targets"], [{"answer": "United States"}])
+        self.assertIn("image_url", payload["groups"][1]["request"])
+
+    def test_train_step_hides_internal_metrics(self):
+        rl_group = RLGroup(
+            request={"skill": "query", "question": "What is this?"},
+            rollouts=[
+                {
+                    "skill": "query",
+                    "finish_reason": "stop",
+                    "output": {"answer": "A photo"},
+                    "answer_tokens": [1],
+                    "thinking_tokens": [],
+                    "has_answer_separator": False,
+                    "coords": [],
+                    "sizes": [],
+                }
+            ],
+            rewards=[1.0],
+        )
+
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"step": 1, "applied": True, "internal_metric": 0.5},
+        ):
+            result = self.client.train_step([rl_group])
+
+        self.assertEqual(result, {"step": 1, "applied": True})
+
+    def test_public_rollout_to_train_step_handoff(self):
+        rollout_response = {
+            "request": {
+                "skill": "query",
+                "question": "What is happening?",
+                "image_url": "data:image/jpeg;base64,abc",
+            },
+            "rollouts": [
+                {
+                    "skill": "query",
+                    "finish_reason": "stop",
+                    "output": {"answer": "People are socializing."},
+                    "answer_tokens": [1],
+                    "thinking_tokens": [],
+                    "has_answer_separator": False,
+                    "coords": [],
+                    "sizes": [],
+                }
+            ],
+        }
+
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            side_effect=[rollout_response, {"step": 4, "applied": True}],
+        ) as mocked:
+            rl_group = self.client.rollouts(
+                {
+                    "skill": "query",
+                    "question": "What is happening?",
+                    "image": self.image,
+                }
+            )
+            result = self.client.train_step([rl_group.with_rewards([1.0])])
+
+        self.assertEqual(result["step"], 4)
+        train_payload = mocked.call_args_list[1].kwargs["payload"]
+        self.assertEqual(
+            train_payload["groups"][0]["request"],
+            rollout_response["request"],
+        )
+        self.assertEqual(train_payload["groups"][0]["rewards"], [1.0])
+
+    def test_train_step_serializes_manual_rl_group_request(self):
+        rl_group = RLGroup(
+            request={
+                "skill": "detect",
+                "object": "vehicles",
+                "image": self.image,
+                "settings": {"temperature": 0.7, "top_p": 0.9, "max_objects": 4},
+            },
+            rollouts=[
+                {
+                    "skill": "detect",
+                    "finish_reason": "stop",
+                    "output": {"objects": []},
+                    "answer_tokens": [],
+                    "thinking_tokens": [],
+                    "has_answer_separator": False,
+                    "coords": [],
+                    "sizes": [],
+                }
+            ],
+            rewards=[0.5],
+        )
+
+        with mock.patch.object(
+            self.client, "_request_json", return_value={"step": 2, "applied": True}
+        ) as mocked:
+            result = self.client.train_step([rl_group])
+
+        self.assertEqual(result["step"], 2)
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["groups"][0]["mode"], "rl")
+        self.assertEqual(payload["groups"][0]["rewards"], [0.5])
+        self.assertEqual(payload["groups"][0]["request"]["skill"], "detect")
+        self.assertEqual(payload["groups"][0]["request"]["object"], "vehicles")
+        self.assertEqual(payload["groups"][0]["request"]["settings"]["max_objects"], 4)
+        self.assertIn("image_url", payload["groups"][0]["request"])
+
+    def test_detect_rollouts_allow_empty_boxes_ground_truth(self):
+        response = {
+            "request": {
+                "skill": "detect",
+                "object": "vehicles",
+                "image_url": "data:image/jpeg;base64,abc",
+            },
+            "rollouts": [],
+        }
+
+        with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
+            self.client.rollouts(
+                {
+                    "skill": "detect",
+                    "object": "vehicles",
+                    "image": self.image,
+                },
+                ground_truth={"boxes": []},
+            )
+
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["ground_truth"], {"boxes": []})
+
+    def test_detect_sft_targets_allow_empty_boxes(self):
+        group = SFTGroup(
+            request={
+                "skill": "detect",
+                "object": "vehicles",
+                "image": self.image,
+            },
+            targets=[{"boxes": []}],
+        )
+
+        with mock.patch.object(
+            self.client, "_request_json", return_value={"step": 5, "applied": True}
+        ) as mocked:
+            result = self.client.train_step([group])
+
+        self.assertEqual(result["step"], 5)
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["groups"][0]["targets"], [{"boxes": []}])
+
+    def test_query_sft_target_validation(self):
+        with self.assertRaises(ValueError):
+            self.client.train_step(
+                [
+                    SFTGroup(
+                        request={
+                            "skill": "query",
+                            "question": "Why?",
+                            "image": self.image,
+                            "reasoning": True,
+                        },
+                        targets=[{"answer": "Because"}],
+                    )
+                ]
+            )
+
+        with self.assertRaises(ValueError):
+            self.client.train_step(
+                [
+                    SFTGroup(
+                        request={
+                            "skill": "query",
+                            "question": "Why?",
+                            "image": self.image,
+                            "reasoning": False,
+                        },
+                        targets=[{"answer": "Because", "reasoning": {"text": "x", "grounding": []}}],
+                    )
+                ]
+            )
+
+        with self.assertRaises(ValueError):
+            self.client.train_step(
+                [
+                    SFTGroup(
+                        request={"skill": "query", "question": "Why?"},
+                        targets=[],
+                    )
+                ]
+            )
+
+    def test_request_json_retries_timeout_then_succeeds(self):
+        attempts = {"count": 0}
+
+        def urlopen(*args, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise urllib.error.URLError(socket.timeout("timed out"))
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen):
+            with mock.patch("time.sleep"):
+                result = self.client._request_json("GET", "/health")
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(attempts["count"], 3)
+
+    def test_request_json_does_not_retry_bad_api_key(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=_http_error(401, {"error": "invalid api key"}),
+        ) as mocked:
+            with self.assertRaises(FinetuneAPIError) as ctx:
+                self.client._request_json("GET", "/finetunes/ft_123")
+
+        self.assertEqual(ctx.exception.status, 401)
+        self.assertEqual(ctx.exception.body, "invalid api key")
+        self.assertIn("401", str(ctx.exception))
+        self.assertEqual(mocked.call_count, 1)
+
+    def test_request_json_retries_524_then_succeeds(self):
+        attempts = {"count": 0}
+
+        def urlopen(*args, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise _http_error(524, "error code: 524")
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen):
+            with mock.patch("time.sleep"):
+                result = self.client._request_json("POST", "/rollouts", payload={"x": 1})
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(attempts["count"], 3)
+
+    def test_rollout_groups_preserves_order_and_concurrency_cap(self):
+        active = {"count": 0, "max": 0}
+
+        async def fake_rollouts_async(spec):
+            active["count"] += 1
+            active["max"] = max(active["max"], active["count"])
+            await __import__("asyncio").sleep(0.01)
+            active["count"] -= 1
+            return RLGroup(
+                request=spec.request,
+                rollouts=[],
+                rewards=[1.0],
+                _request_payload={"skill": spec.request["skill"]},
+            )
+
+        specs = [
+            RolloutSpec(request={"skill": "query", "question": f"q{i}"}, num_rollouts=1)
+            for i in range(5)
+        ]
+
+        with mock.patch.object(self.client, "_rollouts_async", side_effect=fake_rollouts_async):
+            rl_groups = self.client.rollout_groups(specs, max_concurrency=2)
+
+        self.assertEqual([group.request["question"] for group in rl_groups], [f"q{i}" for i in range(5)])
+        self.assertLessEqual(active["max"], 2)
+
+    def test_rollout_groups_drains_in_flight_requests_after_failure(self):
+        client = Finetune(
+            api_key="test-key",
+            endpoint="https://api.example.test/v1/tuning",
+            finetune_id="ft_123",
+            name="demo-ft",
+            rank=8,
+            max_retries=0,
+            retry_base_delay=0.01,
+            retry_max_delay=0.01,
+            timeout=0.01,
+        )
+        q0_started = threading.Event()
+        q1_started = threading.Event()
+        q2_started = threading.Event()
+        release_q0 = threading.Event()
+        started = []
+        result = {}
+
+        def request_json_once(method, path, payload=None, query=None):
+            question = payload["request"]["question"]
+            started.append(question)
+
+            if question == "q0":
+                q0_started.set()
+                self.assertTrue(release_q0.wait(timeout=1))
+                return {"request": payload["request"], "rollouts": []}
+
+            if question == "q1":
+                q1_started.set()
+                self.assertTrue(q0_started.wait(timeout=1))
+                raise urllib.error.URLError("boom")
+
+            q2_started.set()
+            return {"request": payload["request"], "rollouts": []}
+
+        def run_rollout_groups():
+            try:
+                client.rollout_groups(
+                    [
+                        RolloutSpec(request={"skill": "query", "question": "q0"}),
+                        RolloutSpec(request={"skill": "query", "question": "q1"}),
+                        RolloutSpec(request={"skill": "query", "question": "q2"}),
+                    ],
+                    max_concurrency=2,
+                )
+            except Exception as exc:
+                result["error"] = exc
+
+        worker = threading.Thread(target=run_rollout_groups)
+
+        with mock.patch.object(client, "_request_json_once", side_effect=request_json_once):
+            worker.start()
+            self.assertTrue(q0_started.wait(timeout=1))
+            self.assertTrue(q1_started.wait(timeout=1))
+            worker.join(timeout=0.05)
+            self.assertTrue(worker.is_alive())
+            self.assertFalse(q2_started.is_set())
+
+            release_q0.set()
+            worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertIsInstance(result.get("error"), FinetuneAPIError)
+        self.assertEqual(len(started), 2)
+        self.assertCountEqual(started, ["q0", "q1"])
+
+    def test_list_checkpoints_validates_limit(self):
+        with self.assertRaises(ValueError):
+            self.client.list_checkpoints(limit=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -586,6 +586,54 @@ class FinetuneTests(unittest.TestCase):
             query={"limit": 0, "cursor": None},
         )
 
+    def test_save_checkpoint_returns_raw_response(self):
+        response = {
+            "ok": True,
+            "checkpoint": {
+                "checkpoint_id": "ckpt_123",
+                "finetune_id": "ft_123",
+                "step": 7,
+            },
+        }
+
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value=response,
+        ) as mocked:
+            result = self.client.save_checkpoint()
+
+        self.assertEqual(result, response)
+        mocked.assert_called_once_with(
+            "POST",
+            "/finetunes/ft_123/checkpoints/save",
+        )
+
+    def test_delete_returns_raw_response(self):
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"ok": True},
+        ) as mocked:
+            result = self.client.delete()
+
+        self.assertEqual(result, {"ok": True})
+        mocked.assert_called_once_with("DELETE", "/finetunes/ft_123")
+
+    def test_delete_checkpoint_returns_raw_response(self):
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"ok": True},
+        ) as mocked:
+            result = self.client.delete_checkpoint(7)
+
+        self.assertEqual(result, {"ok": True})
+        mocked.assert_called_once_with(
+            "DELETE",
+            "/finetunes/ft_123/checkpoints/7",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -232,7 +232,7 @@ class FinetuneTests(unittest.TestCase):
             skill="query",
             image=self.image,
             question="What is happening?",
-            targets=[{"answer": "People are smiling for a photo."}],
+            target={"answer": "People are smiling for a photo."},
             reasoning=True,
         )
 
@@ -240,7 +240,7 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(group["request"]["skill"], "query")
         self.assertEqual(group["request"]["question"], "What is happening?")
         self.assertTrue(group["request"]["reasoning"])
-        self.assertEqual(group["targets"], [{"answer": "People are smiling for a photo."}])
+        self.assertEqual(group["target"], {"answer": "People are smiling for a photo."})
         self.assertTrue(group["request"]["image_url"].startswith("data:image/jpeg;base64,"))
 
     def test_train_step_builds_mixed_rl_and_sft_payload(self):
@@ -259,7 +259,7 @@ class FinetuneTests(unittest.TestCase):
             skill="query",
             image=self.image,
             question="What country is this?",
-            targets=[{"answer": "United States"}],
+            target={"answer": "United States"},
         )
 
         with mock.patch.object(
@@ -275,7 +275,7 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["groups"][0]["rollouts"], [raw_rollout])
         self.assertEqual(payload["groups"][0]["rewards"], [1.0])
         self.assertEqual(payload["groups"][1]["mode"], "sft")
-        self.assertEqual(payload["groups"][1]["targets"], [{"answer": "United States"}])
+        self.assertEqual(payload["groups"][1]["target"], {"answer": "United States"})
 
     def test_train_step_returns_raw_response(self):
         rl_group: RLGroup = {

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -331,25 +331,31 @@ class FinetuneTests(unittest.TestCase):
             },
         )
 
-    def test_log_metrics_validates_inputs(self):
-        with self.assertRaises(ValueError):
-            self.client.log_metrics(-1, {"eval/score": 1.0})
+    def test_log_metrics_passes_inputs_through_without_local_validation(self):
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"ok": True},
+        ) as mocked:
+            self.client.log_metrics(
+                -1,
+                {
+                    "bad name": 1.0,
+                    "sys/loss": 2.0,
+                },
+            )
 
-        with self.assertRaises(ValueError):
-            self.client.log_metrics(1, {})
-
-        with self.assertRaises(ValueError):
-            self.client.log_metrics(1, {"bad name": 1.0})
-
-        with self.assertRaises(ValueError):
-            self.client.log_metrics(1, {"sys/loss": 1.0})
-
-        with self.assertRaises(ValueError):
-            self.client.log_metrics(1, {"eval/score": float("nan")})
-
-        too_many = {f"eval/m{i}": float(i) for i in range(101)}
-        with self.assertRaises(ValueError):
-            self.client.log_metrics(1, too_many)
+        mocked.assert_called_once_with(
+            "POST",
+            "/finetunes/ft_123/metrics",
+            payload={
+                "step": -1,
+                "metrics": {
+                    "bad name": 1.0,
+                    "sys/loss": 2.0,
+                },
+            },
+        )
 
     def test_public_rollout_to_train_step_handoff(self):
         rollout_response = {
@@ -387,29 +393,29 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(train_payload["groups"][0]["rollouts"], rollout_response["rollouts"])
         self.assertEqual(train_payload["groups"][0]["rewards"], [1.0])
 
-    def test_train_step_rejects_rl_group_without_rewards(self):
+    def test_train_step_passes_groups_through_without_local_validation(self):
         group: RLGroup = {
             "mode": "rl",
             "request": {"skill": "query", "question": "What is this?"},
             "rollouts": [_raw_rollout("query", {"answer": "A photo"})],
         }
 
-        with self.assertRaises(ValueError):
-            self.client.train_step([group])
+        with mock.patch.object(
+            self.client, "_request_json", return_value={"step": 7, "applied": True}
+        ) as mocked:
+            result = self.client.train_step([group])
 
-    def test_train_step_rejects_mutated_rewards_length(self):
-        group: RLGroup = {
-            "mode": "rl",
-            "request": {"skill": "query", "question": "What is this?"},
-            "rollouts": [
-                _raw_rollout("query", {"answer": "A photo"}),
-                _raw_rollout("query", {"answer": "A drawing"}),
-            ],
-            "rewards": [1.0],
-        }
-
-        with self.assertRaises(ValueError):
-            self.client.train_step([group])
+        self.assertEqual(result["step"], 7)
+        mocked.assert_called_once_with(
+            "POST",
+            "/train_step",
+            payload={
+                "finetune_id": "ft_123",
+                "groups": [group],
+                "lr": 0.002,
+            },
+            max_retries=0,
+        )
 
     def test_request_json_retries_timeout_then_succeeds(self):
         attempts = {"count": 0}
@@ -566,9 +572,19 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(len(started), 2)
         self.assertCountEqual(started, ["q0", "q1"])
 
-    def test_list_checkpoints_validates_limit(self):
-        with self.assertRaises(ValueError):
+    def test_list_checkpoints_pass_limit_through_without_local_validation(self):
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"checkpoints": [], "has_more": False},
+        ) as mocked:
             self.client.list_checkpoints(limit=0)
+
+        mocked.assert_called_once_with(
+            "GET",
+            "/finetunes/ft_123/checkpoints",
+            query={"limit": 0, "cursor": None},
+        )
 
 
 if __name__ == "__main__":

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -78,9 +78,6 @@ class FinetuneTests(unittest.TestCase):
             ft(api_key="x", name="bad name", rank=8)
 
         with self.assertRaises(ValueError):
-            ft(api_key="x", name="demo", rank=12)
-
-        with self.assertRaises(ValueError):
             ft(api_key="x", name="demo", rank=8, max_retries=-1)
 
     def test_ft_binds_existing_finetune(self):
@@ -113,17 +110,17 @@ class FinetuneTests(unittest.TestCase):
             client = ft(
                 api_key="x",
                 name="new-ft",
-                rank=8,
+                rank=12,
                 endpoint="https://api.example.test/v1/tuning",
             )
 
         self.assertEqual(client.finetune_id, "ft_789")
         self.assertEqual(client.name, "new-ft")
-        self.assertEqual(client.rank, 8)
+        self.assertEqual(client.rank, 12)
         mocked.assert_called_once_with(
             "POST",
             "/finetunes",
-            payload={"name": "new-ft", "rank": 8},
+            payload={"name": "new-ft", "rank": 12},
         )
 
     def test_query_rollouts_requires_question(self):

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -9,7 +9,7 @@ import moondream as md
 from PIL import Image
 
 from moondream.finetune import Finetune, FinetuneAPIError, ft
-from moondream.types import EncodedImage, RLGroup, RolloutGroup, SFTGroup
+from moondream.types import EncodedImage, RLGroup, RolloutRequest, SFTGroup
 
 
 class _FakeResponse:
@@ -76,17 +76,16 @@ class FinetuneTests(unittest.TestCase):
             ft(api_key="x", name="demo", finetune_id="ft_123")
 
         with self.assertRaises(ValueError):
-            ft(api_key="x", name="bad name", rank=8)
-
-        with self.assertRaises(ValueError):
             ft(api_key="x", name="demo", rank=8, max_retries=-1)
 
     def test_package_exposes_helper_types_under_md_types(self):
         self.assertTrue(hasattr(md, "ft"))
         self.assertTrue(hasattr(md, "types"))
-        self.assertIs(md.types.RolloutGroup, RolloutGroup)
+        self.assertIs(md.types.RolloutRequest, RolloutRequest)
+        self.assertIs(md.types.RLGroup, RLGroup)
         self.assertIs(md.types.SFTGroup, SFTGroup)
-        self.assertFalse(hasattr(md, "RolloutGroup"))
+        self.assertFalse(hasattr(md, "RolloutRequest"))
+        self.assertFalse(hasattr(md, "RLGroup"))
         self.assertFalse(hasattr(md, "SFTGroup"))
 
     def test_ft_binds_existing_finetune(self):
@@ -132,165 +131,133 @@ class FinetuneTests(unittest.TestCase):
             payload={"name": "new-ft", "rank": 12},
         )
 
-    def test_query_rollouts_requires_question(self):
-        with self.assertRaises(ValueError):
-            self.client.query_rollouts(image=self.image)
-
-    def test_detect_rollouts_serializes_request_and_returns_rl_group(self):
-        response = {
-            "request": {
-                "skill": "detect",
-                "object": "vehicles",
-                "image_url": "data:image/jpeg;base64,abc",
-            },
-            "rollouts": [_raw_rollout("detect", {"objects": []})],
-            "rewards": None,
-        }
-
-        with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
-            rl_group = self.client.detect_rollouts(
-                self.image,
-                "vehicles",
-                num_rollouts=2,
-                settings={"temperature": 1.0, "top_p": 1.0, "max_objects": 5},
-            )
-
-        self.assertIsInstance(rl_group, RLGroup)
-        self.assertEqual(rl_group.skill, "detect")
-        self.assertEqual(rl_group.object, "vehicles")
-        self.assertEqual(rl_group.rollouts, [{"objects": []}])
-
-        payload = mocked.call_args.kwargs["payload"]
-        self.assertEqual(payload["finetune_id"], "ft_123")
-        self.assertEqual(payload["num_rollouts"], 2)
-        self.assertEqual(payload["request"]["skill"], "detect")
-        self.assertTrue(payload["request"]["image_url"].startswith("data:image/jpeg;base64,"))
-
-    def test_detect_rollouts_deep_copy_public_outputs(self):
-        response = {
-            "request": {
-                "skill": "detect",
-                "object": "vehicles",
-                "image_url": "data:image/jpeg;base64,abc",
-            },
-            "rollouts": [
-                _raw_rollout(
-                    "detect",
-                    {
-                        "objects": [
-                            {
-                                "x_min": 0.1,
-                                "y_min": 0.2,
-                                "x_max": 0.3,
-                                "y_max": 0.4,
-                            }
-                        ]
-                    },
-                )
-            ],
-        }
-
-        with mock.patch.object(self.client, "_request_json", return_value=response):
-            rl_group = self.client.detect_rollouts(
-                self.image,
-                "vehicles",
-            )
-
-        rl_group.rollouts[0]["objects"].append(
-            {"x_min": 0.5, "y_min": 0.6, "x_max": 0.7, "y_max": 0.8}
-        )
-
-        self.assertEqual(len(rl_group.rollouts[0]["objects"]), 2)
-        self.assertEqual(len(rl_group._rollouts_payload[0]["output"]["objects"]), 1)
-
-    def test_query_rollouts_return_flat_model_outputs(self):
+    def test_rollouts_serializes_request_and_returns_raw_response(self):
         response = {
             "request": {
                 "skill": "query",
                 "question": "What is happening?",
                 "image_url": "data:image/jpeg;base64,abc",
+                "reasoning": True,
+                "settings": {"temperature": 1.0, "top_p": 1.0, "max_tokens": 8},
             },
-            "rollouts": [
-                _raw_rollout("query", {"answer": "People are socializing."}),
-                _raw_rollout("query", {"answer": "Friends are chatting."}),
-            ],
+            "rollouts": [_raw_rollout("query", {"answer": "People are socializing."})],
         }
 
-        with mock.patch.object(self.client, "_request_json", return_value=response):
-            rl_group = self.client.query_rollouts(
-                image=self.image,
-                question="What is happening?",
-                num_rollouts=2,
-            )
-
-        self.assertEqual(rl_group.rollouts[0]["answer"], "People are socializing.")
-        self.assertNotIn("output", rl_group.rollouts[0])
-        self.assertEqual(rl_group.question, "What is happening?")
-
-    def test_query_rollouts_pass_settings_through(self):
-        response = {"request": {"skill": "query", "question": "What is here?"}, "rollouts": []}
+        request = RolloutRequest(
+            skill="query",
+            image=self.image,
+            question="What is happening?",
+            num_rollouts=2,
+            reasoning=True,
+            settings={"temperature": 1.0, "top_p": 1.0, "max_tokens": 8},
+        )
 
         with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
-            self.client.query_rollouts(
-                image=self.image,
-                question="What is here?",
-                settings={"max_objects": 2},
-            )
+            result = self.client.rollouts(request)
+
+        self.assertEqual(result, response)
+        payload = mocked.call_args.kwargs["payload"]
+        self.assertEqual(payload["finetune_id"], "ft_123")
+        self.assertEqual(payload["num_rollouts"], 2)
+        self.assertEqual(payload["request"]["skill"], "query")
+        self.assertEqual(payload["request"]["question"], "What is happening?")
+        self.assertTrue(payload["request"]["image_url"].startswith("data:image/jpeg;base64,"))
+        self.assertTrue(payload["request"]["reasoning"])
+
+    def test_rollouts_pass_settings_through(self):
+        request = RolloutRequest(
+            skill="query",
+            question="What is here?",
+            image=self.image,
+            settings={"max_objects": 2},
+        )
+
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"request": {"skill": "query"}, "rollouts": []},
+        ) as mocked:
+            self.client.rollouts(request)
 
         payload = mocked.call_args.kwargs["payload"]
         self.assertEqual(payload["request"]["settings"]["max_objects"], 2)
 
-    def test_detect_rollouts_pass_settings_through(self):
-        response = {"request": {"skill": "detect", "object": "vehicles"}, "rollouts": []}
+    def test_rollouts_pass_ground_truth_through(self):
+        request = RolloutRequest(
+            skill="detect",
+            image=self.image,
+            object="vehicles",
+            ground_truth={"boxes": []},
+        )
 
-        with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
-            self.client.detect_rollouts(
-                self.image,
-                "vehicles",
-                settings={"max_tokens": 16},
-            )
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"request": {"skill": "detect"}, "rollouts": []},
+        ) as mocked:
+            self.client.rollouts(request)
 
         payload = mocked.call_args.kwargs["payload"]
-        self.assertEqual(payload["request"]["settings"]["max_tokens"], 16)
+        self.assertEqual(payload["ground_truth"], {"boxes": []})
 
     def test_rollouts_reject_unknown_encoded_image(self):
         class FakeEncodedImage(EncodedImage):
             pass
 
         with self.assertRaises(ValueError):
-            self.client.detect_rollouts(FakeEncodedImage(), "vehicles")
+            self.client.rollouts(
+                RolloutRequest(skill="detect", image=FakeEncodedImage(), object="vehicles")
+            )
 
-    def test_rlgroup_rewards_assignment_validates_length(self):
-        rl_group = RLGroup(
-            skill="query",
-            question="hi",
-            rollouts=[{"answer": "hello"}],
-        )
+    def test_batch_rollouts_returns_rl_groups(self):
+        async def fake_rollouts_async(request):
+            return {
+                "request": {
+                    "skill": request.skill,
+                    "question": request.question,
+                },
+                "rollouts": [_raw_rollout(request.skill, {"answer": request.question})],
+                "rewards": [0.5],
+            }
 
+        requests = [
+            RolloutRequest(skill="query", question="q0"),
+            RolloutRequest(skill="query", question="q1"),
+        ]
+
+        with mock.patch.object(self.client, "_rollouts_async", side_effect=fake_rollouts_async):
+            groups = self.client.batch_rollouts(requests, max_concurrency=2)
+
+        self.assertEqual(groups[0]["mode"], "rl")
+        self.assertEqual(groups[0]["request"]["question"], "q0")
+        self.assertEqual(groups[0]["rollouts"][0]["output"]["answer"], "q0")
+        self.assertEqual(groups[0]["rewards"], [0.5])
+
+    def test_batch_rollouts_validates_max_concurrency(self):
         with self.assertRaises(ValueError):
-            rl_group.rewards = [1.0, 0.0]
+            self.client.batch_rollouts([], max_concurrency=0)
 
     def test_train_step_builds_mixed_rl_and_sft_payload(self):
         raw_rollout = _raw_rollout("query", {"answer": "A sign"})
-        rl_group = RLGroup(
-            skill="query",
-            question="What is this?",
-            image=self.image,
-            rollouts=[{"answer": "A sign"}],
-            rewards=[1.0],
-            _request_payload={
+        rl_group: RLGroup = {
+            "mode": "rl",
+            "request": {
                 "skill": "query",
                 "question": "What is this?",
                 "image_url": "data:image/jpeg;base64,abc",
             },
-            _rollouts_payload=[raw_rollout],
-        )
-        sft_group = SFTGroup.query(
-            question="What country is this?",
-            image=self.image,
-            reasoning=False,
-            targets=[{"answer": "United States"}],
-        )
+            "rollouts": [raw_rollout],
+            "rewards": [1.0],
+        }
+        sft_group: SFTGroup = {
+            "mode": "sft",
+            "request": {
+                "skill": "query",
+                "question": "What country is this?",
+                "image_url": "data:image/jpeg;base64,abc",
+            },
+            "targets": [{"answer": "United States"}],
+        }
 
         with mock.patch.object(
             self.client, "_request_json", return_value={"step": 1, "applied": True}
@@ -306,18 +273,14 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["groups"][0]["rewards"], [1.0])
         self.assertEqual(payload["groups"][1]["mode"], "sft")
         self.assertEqual(payload["groups"][1]["targets"], [{"answer": "United States"}])
-        self.assertIn("image_url", payload["groups"][1]["request"])
-        self.assertNotIn("settings", payload["groups"][1]["request"])
 
     def test_train_step_hides_internal_metrics(self):
-        rl_group = RLGroup(
-            skill="query",
-            question="What is this?",
-            rollouts=[{"answer": "A photo"}],
-            rewards=[1.0],
-            _request_payload={"skill": "query", "question": "What is this?"},
-            _rollouts_payload=[_raw_rollout("query", {"answer": "A photo"})],
-        )
+        rl_group: RLGroup = {
+            "mode": "rl",
+            "request": {"skill": "query", "question": "What is this?"},
+            "rollouts": [_raw_rollout("query", {"answer": "A photo"})],
+            "rewards": [1.0],
+        }
 
         with mock.patch.object(
             self.client,
@@ -376,14 +339,13 @@ class FinetuneTests(unittest.TestCase):
             self.client.log_metrics(1, too_many)
 
     def test_public_rollout_to_train_step_handoff(self):
-        raw_rollout = _raw_rollout("query", {"answer": "People are socializing."})
         rollout_response = {
             "request": {
                 "skill": "query",
                 "question": "What is happening?",
                 "image_url": "data:image/jpeg;base64,abc",
             },
-            "rollouts": [raw_rollout],
+            "rollouts": [_raw_rollout("query", {"answer": "People are socializing."})],
         }
 
         with mock.patch.object(
@@ -391,133 +353,50 @@ class FinetuneTests(unittest.TestCase):
             "_request_json",
             side_effect=[rollout_response, {"step": 4, "applied": True}],
         ) as mocked:
-            rl_group = self.client.query_rollouts(
-                image=self.image,
-                question="What is happening?",
+            response = self.client.rollouts(
+                RolloutRequest(
+                    skill="query",
+                    image=self.image,
+                    question="What is happening?",
+                )
             )
-            rl_group.rewards = [1.0]
-            result = self.client.train_step([rl_group])
-
-        self.assertEqual(result["step"], 4)
-        self.assertEqual(rl_group.rollouts, [{"answer": "People are socializing."}])
-        train_payload = mocked.call_args_list[1].kwargs["payload"]
-        self.assertEqual(train_payload["groups"][0]["request"], rollout_response["request"])
-        self.assertEqual(train_payload["groups"][0]["rollouts"], [raw_rollout])
-        self.assertEqual(train_payload["groups"][0]["rewards"], [1.0])
-
-    def test_train_step_rejects_manual_rl_group_without_raw_rollouts(self):
-        rl_group = RLGroup(
-            skill="query",
-            question="What is this?",
-            rollouts=[{"answer": "A photo"}],
-            rewards=[1.0],
-        )
-
-        with self.assertRaises(ValueError):
-            self.client.train_step([rl_group])
-
-    def test_train_step_rejects_mutated_rewards_length(self):
-        rl_group = RLGroup(
-            skill="query",
-            question="What is this?",
-            rollouts=[{"answer": "A photo"}],
-            rewards=[1.0],
-            _request_payload={"skill": "query", "question": "What is this?"},
-            _rollouts_payload=[_raw_rollout("query", {"answer": "A photo"})],
-        )
-        rl_group.rewards.append(0.0)
-
-        with self.assertRaises(ValueError):
-            self.client.train_step([rl_group])
-
-    def test_train_step_rejects_mutated_rollouts_after_generation(self):
-        raw_rollouts = [
-            _raw_rollout("query", {"answer": "A photo"}),
-            _raw_rollout("query", {"answer": "A drawing"}),
-        ]
-        rl_group = RLGroup(
-            skill="query",
-            question="What is this?",
-            rollouts=[{"answer": "A photo"}, {"answer": "A drawing"}],
-            _request_payload={"skill": "query", "question": "What is this?"},
-            _rollouts_payload=raw_rollouts,
-        )
-        rl_group.rollouts = rl_group.rollouts[:1]
-        rl_group.rewards = [1.0]
-
-        with self.assertRaisesRegex(
-            ValueError, "RLGroup rollouts must not be mutated"
-        ):
-            self.client.train_step([rl_group])
-
-    def test_detect_rollouts_allow_empty_boxes_ground_truth(self):
-        response = {
-            "request": {
-                "skill": "detect",
-                "object": "vehicles",
-                "image_url": "data:image/jpeg;base64,abc",
-            },
-            "rollouts": [],
-        }
-
-        with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
-            self.client.detect_rollouts(
-                self.image,
-                "vehicles",
-                ground_truth={"boxes": []},
-            )
-
-        payload = mocked.call_args.kwargs["payload"]
-        self.assertEqual(payload["ground_truth"], {"boxes": []})
-
-    def test_detect_sft_targets_allow_empty_boxes(self):
-        group = SFTGroup.detect(
-            self.image,
-            "vehicles",
-            targets=[{"boxes": []}],
-        )
-
-        with mock.patch.object(
-            self.client, "_request_json", return_value={"step": 5, "applied": True}
-        ) as mocked:
+            group: RLGroup = {
+                "mode": "rl",
+                "request": response["request"],
+                "rollouts": response["rollouts"],
+                "rewards": [1.0],
+            }
             result = self.client.train_step([group])
 
-        self.assertEqual(result["step"], 5)
-        payload = mocked.call_args.kwargs["payload"]
-        self.assertEqual(payload["groups"][0]["targets"], [{"boxes": []}])
+        self.assertEqual(result["step"], 4)
+        train_payload = mocked.call_args_list[1].kwargs["payload"]
+        self.assertEqual(train_payload["groups"][0]["request"], rollout_response["request"])
+        self.assertEqual(train_payload["groups"][0]["rollouts"], rollout_response["rollouts"])
+        self.assertEqual(train_payload["groups"][0]["rewards"], [1.0])
 
-    def test_query_sft_target_validation(self):
-        with self.assertRaises(ValueError):
-            self.client.train_step(
-                [
-                    SFTGroup.query(
-                        question="Why?",
-                        image=self.image,
-                        reasoning=True,
-                        targets=[{"answer": "Because"}],
-                    )
-                ]
-            )
+    def test_train_step_rejects_rl_group_without_rewards(self):
+        group: RLGroup = {
+            "mode": "rl",
+            "request": {"skill": "query", "question": "What is this?"},
+            "rollouts": [_raw_rollout("query", {"answer": "A photo"})],
+        }
 
         with self.assertRaises(ValueError):
-            self.client.train_step(
-                [
-                    SFTGroup.query(
-                        question="Why?",
-                        image=self.image,
-                        reasoning=False,
-                        targets=[
-                            {
-                                "answer": "Because",
-                                "reasoning": {"text": "x", "grounding": []},
-                            }
-                        ],
-                    )
-                ]
-            )
+            self.client.train_step([group])
+
+    def test_train_step_rejects_mutated_rewards_length(self):
+        group: RLGroup = {
+            "mode": "rl",
+            "request": {"skill": "query", "question": "What is this?"},
+            "rollouts": [
+                _raw_rollout("query", {"answer": "A photo"}),
+                _raw_rollout("query", {"answer": "A drawing"}),
+            ],
+            "rewards": [1.0],
+        }
 
         with self.assertRaises(ValueError):
-            self.client.train_step([SFTGroup.query(question="Why?", targets=[])])
+            self.client.train_step([group])
 
     def test_request_json_retries_timeout_then_succeeds(self):
         attempts = {"count": 0}
@@ -564,31 +443,50 @@ class FinetuneTests(unittest.TestCase):
         for error in errors:
             error.close.assert_called_once()
 
-    def test_rollout_groups_preserves_order_and_concurrency_cap(self):
+    def test_train_step_does_not_retry_timeout(self):
+        group: RLGroup = {
+            "mode": "rl",
+            "request": {"skill": "query", "question": "What is this?"},
+            "rollouts": [_raw_rollout("query", {"answer": "A photo"})],
+            "rewards": [1.0],
+        }
+
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError(socket.timeout("timed out")),
+        ) as mocked:
+            with mock.patch("time.sleep") as mocked_sleep:
+                with self.assertRaises(FinetuneAPIError):
+                    self.client.train_step([group])
+
+        self.assertEqual(mocked.call_count, 1)
+        mocked_sleep.assert_not_called()
+
+    def test_batch_rollouts_preserves_order_and_concurrency_cap(self):
         active = {"count": 0, "max": 0}
 
-        async def fake_rollouts_async(group):
+        async def fake_rollouts_async(request):
             active["count"] += 1
             active["max"] = max(active["max"], active["count"])
             await __import__("asyncio").sleep(0.01)
             active["count"] -= 1
-            return RLGroup(
-                skill=group.skill,
-                question=group.question,
-                rollouts=[],
-                _request_payload={"skill": group.skill},
-                _rollouts_payload=[],
-            )
+            return {
+                "request": {"skill": request.skill, "question": request.question},
+                "rollouts": [],
+            }
 
-        groups = [RolloutGroup.query(question=f"q{i}") for i in range(5)]
+        requests = [RolloutRequest(skill="query", question=f"q{i}") for i in range(5)]
 
         with mock.patch.object(self.client, "_rollouts_async", side_effect=fake_rollouts_async):
-            rl_groups = self.client.rollout_groups(groups, max_concurrency=2)
+            groups = self.client.batch_rollouts(requests, max_concurrency=2)
 
-        self.assertEqual([group.question for group in rl_groups], [f"q{i}" for i in range(5)])
+        self.assertEqual(
+            [group["request"]["question"] for group in groups],
+            [f"q{i}" for i in range(5)],
+        )
         self.assertLessEqual(active["max"], 2)
 
-    def test_rollout_groups_drains_in_flight_requests_after_failure(self):
+    def test_batch_rollouts_drains_in_flight_requests_after_failure(self):
         client = Finetune(
             api_key="test-key",
             endpoint="https://api.example.test/v1/tuning",
@@ -624,20 +522,20 @@ class FinetuneTests(unittest.TestCase):
             q2_started.set()
             return {"request": payload["request"], "rollouts": []}
 
-        def run_rollout_groups():
+        def run_batch_rollouts():
             try:
-                client.rollout_groups(
+                client.batch_rollouts(
                     [
-                        RolloutGroup.query(question="q0"),
-                        RolloutGroup.query(question="q1"),
-                        RolloutGroup.query(question="q2"),
+                        RolloutRequest(skill="query", question="q0"),
+                        RolloutRequest(skill="query", question="q1"),
+                        RolloutRequest(skill="query", question="q2"),
                     ],
                     max_concurrency=2,
                 )
             except Exception as exc:
                 result["error"] = exc
 
-        worker = threading.Thread(target=run_rollout_groups)
+        worker = threading.Thread(target=run_batch_rollouts)
 
         with mock.patch.object(client, "_request_json_once", side_effect=request_json_once):
             worker.start()

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -7,9 +7,8 @@ from unittest import mock
 
 from PIL import Image
 
-import moondream as md
 from moondream.finetune import Finetune, FinetuneAPIError, ft
-from moondream.types import EncodedImage, RLGroup, RolloutSpec, SFTGroup
+from moondream.types import EncodedImage, RLGroup, RolloutGroup, SFTGroup
 
 
 class _FakeResponse:
@@ -36,6 +35,19 @@ def _http_error(status, body, headers=None):
         hdrs=headers or {},
         fp=mock.Mock(read=mock.Mock(return_value=body)),
     )
+
+
+def _raw_rollout(skill, output):
+    return {
+        "skill": skill,
+        "finish_reason": "stop",
+        "output": output,
+        "answer_tokens": [1],
+        "thinking_tokens": [],
+        "has_answer_separator": False,
+        "coords": [],
+        "sizes": [],
+    }
 
 
 class FinetuneTests(unittest.TestCase):
@@ -112,40 +124,33 @@ class FinetuneTests(unittest.TestCase):
             payload={"name": "new-ft", "rank": 8},
         )
 
-    def test_rollouts_serializes_request_and_returns_rl_group(self):
-        request = {
-            "skill": "detect",
-            "object": "vehicles",
-            "image": self.image,
-            "settings": {"temperature": 1.0, "top_p": 1.0, "max_objects": 5},
-        }
+    def test_query_rollouts_requires_question(self):
+        with self.assertRaises(ValueError):
+            self.client.query_rollouts(image=self.image)
+
+    def test_detect_rollouts_serializes_request_and_returns_rl_group(self):
         response = {
             "request": {
                 "skill": "detect",
                 "object": "vehicles",
                 "image_url": "data:image/jpeg;base64,abc",
             },
-            "rollouts": [
-                {
-                    "skill": "detect",
-                    "finish_reason": "stop",
-                    "output": {"objects": []},
-                    "answer_tokens": [],
-                    "thinking_tokens": [],
-                    "has_answer_separator": False,
-                    "coords": [],
-                    "sizes": [],
-                }
-            ],
+            "rollouts": [_raw_rollout("detect", {"objects": []})],
             "rewards": None,
         }
 
         with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
-            rl_group = self.client.rollouts(request, num_rollouts=2)
+            rl_group = self.client.detect_rollouts(
+                self.image,
+                "vehicles",
+                num_rollouts=2,
+                settings={"temperature": 1.0, "top_p": 1.0, "max_objects": 5},
+            )
 
         self.assertIsInstance(rl_group, RLGroup)
-        self.assertEqual(rl_group.request, request)
-        self.assertEqual(len(rl_group.rollouts), 1)
+        self.assertEqual(rl_group.skill, "detect")
+        self.assertEqual(rl_group.object, "vehicles")
+        self.assertEqual(rl_group.rollouts, [{"objects": []}])
 
         payload = mocked.call_args.kwargs["payload"]
         self.assertEqual(payload["finetune_id"], "ft_123")
@@ -153,11 +158,44 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["request"]["skill"], "detect")
         self.assertTrue(payload["request"]["image_url"].startswith("data:image/jpeg;base64,"))
 
-    def test_rollouts_rejects_query_ground_truth(self):
+    def test_query_rollouts_return_flat_model_outputs(self):
+        response = {
+            "request": {
+                "skill": "query",
+                "question": "What is happening?",
+                "image_url": "data:image/jpeg;base64,abc",
+            },
+            "rollouts": [
+                _raw_rollout("query", {"answer": "People are socializing."}),
+                _raw_rollout("query", {"answer": "Friends are chatting."}),
+            ],
+        }
+
+        with mock.patch.object(self.client, "_request_json", return_value=response):
+            rl_group = self.client.query_rollouts(
+                image=self.image,
+                question="What is happening?",
+                num_rollouts=2,
+            )
+
+        self.assertEqual(rl_group.rollouts[0]["answer"], "People are socializing.")
+        self.assertNotIn("output", rl_group.rollouts[0])
+        self.assertEqual(rl_group.question, "What is happening?")
+
+    def test_query_rollouts_reject_invalid_settings(self):
         with self.assertRaises(ValueError):
-            self.client.rollouts(
-                {"skill": "query", "question": "What is here?", "image": self.image},
-                ground_truth={"boxes": []},
+            self.client.query_rollouts(
+                image=self.image,
+                question="What is here?",
+                settings={"max_objects": 2},
+            )
+
+    def test_detect_rollouts_reject_invalid_settings(self):
+        with self.assertRaises(ValueError):
+            self.client.detect_rollouts(
+                self.image,
+                "vehicles",
+                settings={"max_tokens": 16},
             )
 
     def test_rollouts_reject_unknown_encoded_image(self):
@@ -165,64 +203,38 @@ class FinetuneTests(unittest.TestCase):
             pass
 
         with self.assertRaises(ValueError):
-            self.client.rollouts(
-                {
-                    "skill": "detect",
-                    "object": "vehicles",
-                    "image": FakeEncodedImage(),
-                }
-            )
+            self.client.detect_rollouts(FakeEncodedImage(), "vehicles")
 
     def test_rlgroup_with_rewards_validates_length(self):
         rl_group = RLGroup(
-            request={"skill": "query", "question": "hi"},
-            rollouts=[
-                {
-                    "skill": "query",
-                    "finish_reason": "stop",
-                    "output": {"answer": "hello"},
-                    "answer_tokens": [],
-                    "thinking_tokens": [],
-                    "has_answer_separator": False,
-                    "coords": [],
-                    "sizes": [],
-                }
-            ],
+            skill="query",
+            question="hi",
+            rollouts=[{"answer": "hello"}],
         )
 
         with self.assertRaises(ValueError):
             rl_group.with_rewards([1.0, 0.0])
 
     def test_train_step_builds_mixed_rl_and_sft_payload(self):
+        raw_rollout = _raw_rollout("query", {"answer": "A sign"})
         rl_group = RLGroup(
-            request={"skill": "query", "question": "What is this?", "image": self.image},
-            rollouts=[
-                {
-                    "skill": "query",
-                    "finish_reason": "stop",
-                    "output": {"answer": "A sign"},
-                    "answer_tokens": [1],
-                    "thinking_tokens": [],
-                    "has_answer_separator": False,
-                    "coords": [],
-                    "sizes": [],
-                }
-            ],
+            skill="query",
+            question="What is this?",
+            image=self.image,
+            rollouts=[{"answer": "A sign"}],
             rewards=[1.0],
             _request_payload={
                 "skill": "query",
                 "question": "What is this?",
                 "image_url": "data:image/jpeg;base64,abc",
             },
+            _rollouts_payload=[raw_rollout],
         )
-        sft_group = SFTGroup(
-            request={
-                "skill": "query",
-                "question": "What country is this?",
-                "image": self.image,
-                "reasoning": False,
-                "settings": {"temperature": 0.0, "top_p": 1.0, "max_tokens": 16},
-            },
+        sft_group = SFTGroup.query(
+            question="What country is this?",
+            image=self.image,
+            reasoning=False,
+            settings={"temperature": 0.0, "top_p": 1.0, "max_tokens": 16},
             targets=[{"answer": "United States"}],
         )
 
@@ -236,6 +248,7 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["finetune_id"], "ft_123")
         self.assertEqual(payload["lr"], 0.003)
         self.assertEqual(payload["groups"][0]["mode"], "rl")
+        self.assertEqual(payload["groups"][0]["rollouts"], [raw_rollout])
         self.assertEqual(payload["groups"][0]["rewards"], [1.0])
         self.assertEqual(payload["groups"][1]["mode"], "sft")
         self.assertEqual(payload["groups"][1]["targets"], [{"answer": "United States"}])
@@ -243,20 +256,12 @@ class FinetuneTests(unittest.TestCase):
 
     def test_train_step_hides_internal_metrics(self):
         rl_group = RLGroup(
-            request={"skill": "query", "question": "What is this?"},
-            rollouts=[
-                {
-                    "skill": "query",
-                    "finish_reason": "stop",
-                    "output": {"answer": "A photo"},
-                    "answer_tokens": [1],
-                    "thinking_tokens": [],
-                    "has_answer_separator": False,
-                    "coords": [],
-                    "sizes": [],
-                }
-            ],
+            skill="query",
+            question="What is this?",
+            rollouts=[{"answer": "A photo"}],
             rewards=[1.0],
+            _request_payload={"skill": "query", "question": "What is this?"},
+            _rollouts_payload=[_raw_rollout("query", {"answer": "A photo"})],
         )
 
         with mock.patch.object(
@@ -269,24 +274,14 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(result, {"step": 1, "applied": True})
 
     def test_public_rollout_to_train_step_handoff(self):
+        raw_rollout = _raw_rollout("query", {"answer": "People are socializing."})
         rollout_response = {
             "request": {
                 "skill": "query",
                 "question": "What is happening?",
                 "image_url": "data:image/jpeg;base64,abc",
             },
-            "rollouts": [
-                {
-                    "skill": "query",
-                    "finish_reason": "stop",
-                    "output": {"answer": "People are socializing."},
-                    "answer_tokens": [1],
-                    "thinking_tokens": [],
-                    "has_answer_separator": False,
-                    "coords": [],
-                    "sizes": [],
-                }
-            ],
+            "rollouts": [raw_rollout],
         }
 
         with mock.patch.object(
@@ -294,59 +289,29 @@ class FinetuneTests(unittest.TestCase):
             "_request_json",
             side_effect=[rollout_response, {"step": 4, "applied": True}],
         ) as mocked:
-            rl_group = self.client.rollouts(
-                {
-                    "skill": "query",
-                    "question": "What is happening?",
-                    "image": self.image,
-                }
+            rl_group = self.client.query_rollouts(
+                image=self.image,
+                question="What is happening?",
             )
             result = self.client.train_step([rl_group.with_rewards([1.0])])
 
         self.assertEqual(result["step"], 4)
+        self.assertEqual(rl_group.rollouts, [{"answer": "People are socializing."}])
         train_payload = mocked.call_args_list[1].kwargs["payload"]
-        self.assertEqual(
-            train_payload["groups"][0]["request"],
-            rollout_response["request"],
-        )
+        self.assertEqual(train_payload["groups"][0]["request"], rollout_response["request"])
+        self.assertEqual(train_payload["groups"][0]["rollouts"], [raw_rollout])
         self.assertEqual(train_payload["groups"][0]["rewards"], [1.0])
 
-    def test_train_step_serializes_manual_rl_group_request(self):
+    def test_train_step_rejects_manual_rl_group_without_raw_rollouts(self):
         rl_group = RLGroup(
-            request={
-                "skill": "detect",
-                "object": "vehicles",
-                "image": self.image,
-                "settings": {"temperature": 0.7, "top_p": 0.9, "max_objects": 4},
-            },
-            rollouts=[
-                {
-                    "skill": "detect",
-                    "finish_reason": "stop",
-                    "output": {"objects": []},
-                    "answer_tokens": [],
-                    "thinking_tokens": [],
-                    "has_answer_separator": False,
-                    "coords": [],
-                    "sizes": [],
-                }
-            ],
-            rewards=[0.5],
+            skill="query",
+            question="What is this?",
+            rollouts=[{"answer": "A photo"}],
+            rewards=[1.0],
         )
 
-        with mock.patch.object(
-            self.client, "_request_json", return_value={"step": 2, "applied": True}
-        ) as mocked:
-            result = self.client.train_step([rl_group])
-
-        self.assertEqual(result["step"], 2)
-        payload = mocked.call_args.kwargs["payload"]
-        self.assertEqual(payload["groups"][0]["mode"], "rl")
-        self.assertEqual(payload["groups"][0]["rewards"], [0.5])
-        self.assertEqual(payload["groups"][0]["request"]["skill"], "detect")
-        self.assertEqual(payload["groups"][0]["request"]["object"], "vehicles")
-        self.assertEqual(payload["groups"][0]["request"]["settings"]["max_objects"], 4)
-        self.assertIn("image_url", payload["groups"][0]["request"])
+        with self.assertRaises(ValueError):
+            self.client.train_step([rl_group])
 
     def test_detect_rollouts_allow_empty_boxes_ground_truth(self):
         response = {
@@ -359,12 +324,9 @@ class FinetuneTests(unittest.TestCase):
         }
 
         with mock.patch.object(self.client, "_request_json", return_value=response) as mocked:
-            self.client.rollouts(
-                {
-                    "skill": "detect",
-                    "object": "vehicles",
-                    "image": self.image,
-                },
+            self.client.detect_rollouts(
+                self.image,
+                "vehicles",
                 ground_truth={"boxes": []},
             )
 
@@ -372,12 +334,9 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["ground_truth"], {"boxes": []})
 
     def test_detect_sft_targets_allow_empty_boxes(self):
-        group = SFTGroup(
-            request={
-                "skill": "detect",
-                "object": "vehicles",
-                "image": self.image,
-            },
+        group = SFTGroup.detect(
+            self.image,
+            "vehicles",
             targets=[{"boxes": []}],
         )
 
@@ -394,13 +353,10 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.client.train_step(
                 [
-                    SFTGroup(
-                        request={
-                            "skill": "query",
-                            "question": "Why?",
-                            "image": self.image,
-                            "reasoning": True,
-                        },
+                    SFTGroup.query(
+                        question="Why?",
+                        image=self.image,
+                        reasoning=True,
                         targets=[{"answer": "Because"}],
                     )
                 ]
@@ -409,27 +365,22 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.client.train_step(
                 [
-                    SFTGroup(
-                        request={
-                            "skill": "query",
-                            "question": "Why?",
-                            "image": self.image,
-                            "reasoning": False,
-                        },
-                        targets=[{"answer": "Because", "reasoning": {"text": "x", "grounding": []}}],
+                    SFTGroup.query(
+                        question="Why?",
+                        image=self.image,
+                        reasoning=False,
+                        targets=[
+                            {
+                                "answer": "Because",
+                                "reasoning": {"text": "x", "grounding": []},
+                            }
+                        ],
                     )
                 ]
             )
 
         with self.assertRaises(ValueError):
-            self.client.train_step(
-                [
-                    SFTGroup(
-                        request={"skill": "query", "question": "Why?"},
-                        targets=[],
-                    )
-                ]
-            )
+            self.client.train_step([SFTGroup.query(question="Why?", targets=[])])
 
     def test_request_json_retries_timeout_then_succeeds(self):
         attempts = {"count": 0}
@@ -479,27 +430,26 @@ class FinetuneTests(unittest.TestCase):
     def test_rollout_groups_preserves_order_and_concurrency_cap(self):
         active = {"count": 0, "max": 0}
 
-        async def fake_rollouts_async(spec):
+        async def fake_rollouts_async(group):
             active["count"] += 1
             active["max"] = max(active["max"], active["count"])
             await __import__("asyncio").sleep(0.01)
             active["count"] -= 1
             return RLGroup(
-                request=spec.request,
+                skill=group.skill,
+                question=group.question,
                 rollouts=[],
                 rewards=[1.0],
-                _request_payload={"skill": spec.request["skill"]},
+                _request_payload={"skill": group.skill},
+                _rollouts_payload=[],
             )
 
-        specs = [
-            RolloutSpec(request={"skill": "query", "question": f"q{i}"}, num_rollouts=1)
-            for i in range(5)
-        ]
+        groups = [RolloutGroup.query(question=f"q{i}") for i in range(5)]
 
         with mock.patch.object(self.client, "_rollouts_async", side_effect=fake_rollouts_async):
-            rl_groups = self.client.rollout_groups(specs, max_concurrency=2)
+            rl_groups = self.client.rollout_groups(groups, max_concurrency=2)
 
-        self.assertEqual([group.request["question"] for group in rl_groups], [f"q{i}" for i in range(5)])
+        self.assertEqual([group.question for group in rl_groups], [f"q{i}" for i in range(5)])
         self.assertLessEqual(active["max"], 2)
 
     def test_rollout_groups_drains_in_flight_requests_after_failure(self):
@@ -542,9 +492,9 @@ class FinetuneTests(unittest.TestCase):
             try:
                 client.rollout_groups(
                     [
-                        RolloutSpec(request={"skill": "query", "question": "q0"}),
-                        RolloutSpec(request={"skill": "query", "question": "q1"}),
-                        RolloutSpec(request={"skill": "query", "question": "q2"}),
+                        RolloutGroup.query(question="q0"),
+                        RolloutGroup.query(question="q1"),
+                        RolloutGroup.query(question="q2"),
                     ],
                     max_concurrency=2,
                 )

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -5,6 +5,7 @@ import unittest
 import urllib.error
 from unittest import mock
 
+import moondream as md
 from PIL import Image
 
 from moondream.finetune import Finetune, FinetuneAPIError, ft
@@ -79,6 +80,14 @@ class FinetuneTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             ft(api_key="x", name="demo", rank=8, max_retries=-1)
+
+    def test_package_exposes_helper_types_under_md_types(self):
+        self.assertTrue(hasattr(md, "ft"))
+        self.assertTrue(hasattr(md, "types"))
+        self.assertIs(md.types.RolloutGroup, RolloutGroup)
+        self.assertIs(md.types.SFTGroup, SFTGroup)
+        self.assertFalse(hasattr(md, "RolloutGroup"))
+        self.assertFalse(hasattr(md, "SFTGroup"))
 
     def test_ft_binds_existing_finetune(self):
         response = {

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -287,7 +287,7 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["groups"][1]["mode"], "sft")
         self.assertEqual(payload["groups"][1]["targets"], [{"answer": "United States"}])
 
-    def test_train_step_hides_internal_metrics(self):
+    def test_train_step_returns_raw_response(self):
         rl_group: RLGroup = {
             "mode": "rl",
             "request": {"skill": "query", "question": "What is this?"},
@@ -302,7 +302,7 @@ class FinetuneTests(unittest.TestCase):
         ):
             result = self.client.train_step([rl_group])
 
-        self.assertEqual(result, {"step": 1, "applied": True})
+        self.assertEqual(result, {"step": 1, "applied": True, "internal_metric": 0.5})
 
     def test_log_metrics_builds_payload_and_returns_response(self):
         with mock.patch.object(

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -28,13 +28,15 @@ class _FakeResponse:
 def _http_error(status, body, headers=None):
     if isinstance(body, dict):
         body = json.dumps(body).encode("utf-8")
-    return urllib.error.HTTPError(
+    error = urllib.error.HTTPError(
         url="https://example.test",
         code=status,
         msg="error",
         hdrs=headers or {},
         fp=mock.Mock(read=mock.Mock(return_value=body)),
     )
+    error.close = mock.Mock()
+    return error
 
 
 def _raw_rollout(skill, output):
@@ -471,9 +473,10 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(attempts["count"], 3)
 
     def test_request_json_does_not_retry_bad_api_key(self):
+        error = _http_error(401, {"error": "invalid api key"})
         with mock.patch(
             "urllib.request.urlopen",
-            side_effect=_http_error(401, {"error": "invalid api key"}),
+            side_effect=error,
         ) as mocked:
             with self.assertRaises(FinetuneAPIError) as ctx:
                 self.client._request_json("GET", "/finetunes/ft_123")
@@ -482,22 +485,21 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(ctx.exception.body, "invalid api key")
         self.assertIn("401", str(ctx.exception))
         self.assertEqual(mocked.call_count, 1)
+        error.close.assert_called_once()
 
     def test_request_json_retries_524_then_succeeds(self):
-        attempts = {"count": 0}
+        errors = [_http_error(524, "error code: 524"), _http_error(524, "error code: 524")]
 
-        def urlopen(*args, **kwargs):
-            attempts["count"] += 1
-            if attempts["count"] < 3:
-                raise _http_error(524, "error code: 524")
-            return _FakeResponse({"ok": True})
-
-        with mock.patch("urllib.request.urlopen", side_effect=urlopen):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=[errors[0], errors[1], _FakeResponse({"ok": True})],
+        ):
             with mock.patch("time.sleep"):
                 result = self.client._request_json("POST", "/rollouts", payload={"x": 1})
 
         self.assertEqual(result, {"ok": True})
-        self.assertEqual(attempts["count"], 3)
+        for error in errors:
+            error.close.assert_called_once()
 
     def test_rollout_groups_preserves_order_and_concurrency_cap(self):
         active = {"count": 0, "max": 0}

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -9,7 +9,7 @@ from unittest import mock
 import moondream as md
 from PIL import Image
 
-from moondream.finetune import Finetune, FinetuneAPIError, ft
+from moondream.finetune import Finetune, ft
 from moondream.types import EncodedImage, RLGroup, SFTGroup
 
 
@@ -433,28 +433,24 @@ class FinetuneTests(unittest.TestCase):
             "urllib.request.urlopen",
             side_effect=error,
         ) as mocked:
-            with self.assertRaises(FinetuneAPIError) as ctx:
+            with self.assertRaises(urllib.error.HTTPError):
                 self.client._request_json("GET", "/finetunes/ft_123")
 
-        self.assertEqual(ctx.exception.status, 401)
-        self.assertEqual(ctx.exception.body, "invalid api key")
-        self.assertIn("401", str(ctx.exception))
         self.assertEqual(mocked.call_count, 1)
-        error.close.assert_called_once()
 
     def test_request_json_retries_524_then_succeeds(self):
-        errors = [_http_error(524, "error code: 524"), _http_error(524, "error code: 524")]
-
         with mock.patch(
             "urllib.request.urlopen",
-            side_effect=[errors[0], errors[1], _FakeResponse({"ok": True})],
+            side_effect=[
+                _http_error(524, "error code: 524"),
+                _http_error(524, "error code: 524"),
+                _FakeResponse({"ok": True}),
+            ],
         ):
             with mock.patch("time.sleep"):
                 result = self.client._request_json("POST", "/rollouts", payload={"x": 1})
 
         self.assertEqual(result, {"ok": True})
-        for error in errors:
-            error.close.assert_called_once()
 
     def test_train_step_does_not_retry_timeout(self):
         group: RLGroup = {
@@ -469,7 +465,7 @@ class FinetuneTests(unittest.TestCase):
             side_effect=urllib.error.URLError(socket.timeout("timed out")),
         ) as mocked:
             with mock.patch("time.sleep") as mocked_sleep:
-                with self.assertRaises(FinetuneAPIError):
+                with self.assertRaises(urllib.error.URLError):
                     self.client.train_step([group])
 
         self.assertEqual(mocked.call_count, 1)
@@ -505,7 +501,7 @@ class FinetuneTests(unittest.TestCase):
         def fake_rollouts(skill, **kwargs):
             call_count[0] += 1
             if call_count[0] == 2:
-                raise FinetuneAPIError("boom")
+                raise RuntimeError("boom")
             time.sleep(0.02)
             return {
                 "request": {"skill": skill, "question": kwargs.get("question", "")},
@@ -515,7 +511,7 @@ class FinetuneTests(unittest.TestCase):
         items = [(i, {"skill": "query", "question": f"q{i}"}) for i in range(10)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
-            with self.assertRaises(FinetuneAPIError):
+            with self.assertRaises(RuntimeError):
                 list(self.client.rollout_stream(items, max_concurrency=2))
 
     def test_rollout_stream_stops_before_extra_requests_on_error(self):
@@ -529,7 +525,7 @@ class FinetuneTests(unittest.TestCase):
             with lock:
                 started.append(question)
             if question == "q1":
-                raise FinetuneAPIError("boom")
+                raise RuntimeError("boom")
             time.sleep(0.1)
             return {
                 "request": {"skill": skill, "question": question},
@@ -539,7 +535,7 @@ class FinetuneTests(unittest.TestCase):
         items = [(i, {"skill": "query", "question": f"q{i}"}) for i in range(20)]
 
         with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
-            with self.assertRaises(FinetuneAPIError):
+            with self.assertRaises(RuntimeError):
                 list(self.client.rollout_stream(
                     items, max_concurrency=2, buffer_size=1,
                 ))

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -283,6 +283,53 @@ class FinetuneTests(unittest.TestCase):
 
         self.assertEqual(result, {"step": 1, "applied": True})
 
+    def test_log_metrics_builds_payload_and_returns_response(self):
+        with mock.patch.object(
+            self.client,
+            "_request_json",
+            return_value={"ok": True, "step": 100, "logged_count": 2},
+        ) as mocked:
+            result = self.client.log_metrics(
+                100,
+                {
+                    "eval/country_match": 0.63,
+                    "eval/token_f1": 0.64,
+                },
+            )
+
+        self.assertEqual(result, {"ok": True, "step": 100, "logged_count": 2})
+        mocked.assert_called_once_with(
+            "POST",
+            "/finetunes/ft_123/metrics",
+            payload={
+                "step": 100,
+                "metrics": {
+                    "eval/country_match": 0.63,
+                    "eval/token_f1": 0.64,
+                },
+            },
+        )
+
+    def test_log_metrics_validates_inputs(self):
+        with self.assertRaises(ValueError):
+            self.client.log_metrics(-1, {"eval/score": 1.0})
+
+        with self.assertRaises(ValueError):
+            self.client.log_metrics(1, {})
+
+        with self.assertRaises(ValueError):
+            self.client.log_metrics(1, {"bad name": 1.0})
+
+        with self.assertRaises(ValueError):
+            self.client.log_metrics(1, {"sys/loss": 1.0})
+
+        with self.assertRaises(ValueError):
+            self.client.log_metrics(1, {"eval/score": float("nan")})
+
+        too_many = {f"eval/m{i}": float(i) for i in range(101)}
+        with self.assertRaises(ValueError):
+            self.client.log_metrics(1, too_many)
+
     def test_public_rollout_to_train_step_handoff(self):
         raw_rollout = _raw_rollout("query", {"answer": "People are socializing."})
         rollout_response = {

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -1,6 +1,7 @@
 import json
 import socket
 import threading
+import time
 import unittest
 import urllib.error
 from unittest import mock
@@ -209,8 +210,8 @@ class FinetuneTests(unittest.TestCase):
                 RolloutRequest(skill="detect", image=FakeEncodedImage(), object="vehicles")
             )
 
-    def test_batch_rollouts_returns_rl_groups(self):
-        async def fake_rollouts_async(request):
+    def test_rollout_stream_yields_responses(self):
+        def fake_rollouts(request):
             return {
                 "request": {
                     "skill": request.skill,
@@ -225,17 +226,18 @@ class FinetuneTests(unittest.TestCase):
             RolloutRequest(skill="query", question="q1"),
         ]
 
-        with mock.patch.object(self.client, "_rollouts_async", side_effect=fake_rollouts_async):
-            groups = self.client.batch_rollouts(requests, max_concurrency=2)
+        with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
+            responses = list(self.client.rollout_stream(requests, max_concurrency=2))
 
-        self.assertEqual(groups[0]["mode"], "rl")
-        self.assertEqual(groups[0]["request"]["question"], "q0")
-        self.assertEqual(groups[0]["rollouts"][0]["output"]["answer"], "q0")
-        self.assertEqual(groups[0]["rewards"], [0.5])
+        self.assertEqual(len(responses), 2)
+        questions = {r["request"]["question"] for r in responses}
+        self.assertEqual(questions, {"q0", "q1"})
 
-    def test_batch_rollouts_validates_max_concurrency(self):
+    def test_rollout_stream_validates_params(self):
         with self.assertRaises(ValueError):
-            self.client.batch_rollouts([], max_concurrency=0)
+            list(self.client.rollout_stream([], max_concurrency=0))
+        with self.assertRaises(ValueError):
+            list(self.client.rollout_stream([], buffer_size=0))
 
     def test_build_sft_group_builds_http_shaped_group(self):
         group = self.client.build_sft_group(
@@ -481,14 +483,17 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(mocked.call_count, 1)
         mocked_sleep.assert_not_called()
 
-    def test_batch_rollouts_preserves_order_and_concurrency_cap(self):
+    def test_rollout_stream_respects_concurrency_cap(self):
         active = {"count": 0, "max": 0}
+        lock = threading.Lock()
 
-        async def fake_rollouts_async(request):
-            active["count"] += 1
-            active["max"] = max(active["max"], active["count"])
-            await __import__("asyncio").sleep(0.01)
-            active["count"] -= 1
+        def fake_rollouts(request):
+            with lock:
+                active["count"] += 1
+                active["max"] = max(active["max"], active["count"])
+            time.sleep(0.02)
+            with lock:
+                active["count"] -= 1
             return {
                 "request": {"skill": request.skill, "question": request.question},
                 "rollouts": [],
@@ -496,81 +501,75 @@ class FinetuneTests(unittest.TestCase):
 
         requests = [RolloutRequest(skill="query", question=f"q{i}") for i in range(5)]
 
-        with mock.patch.object(self.client, "_rollouts_async", side_effect=fake_rollouts_async):
-            groups = self.client.batch_rollouts(requests, max_concurrency=2)
+        with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
+            responses = list(self.client.rollout_stream(requests, max_concurrency=2))
 
-        self.assertEqual(
-            [group["request"]["question"] for group in groups],
-            [f"q{i}" for i in range(5)],
-        )
+        self.assertEqual(len(responses), 5)
         self.assertLessEqual(active["max"], 2)
 
-    def test_batch_rollouts_drains_in_flight_requests_after_failure(self):
-        client = Finetune(
-            api_key="test-key",
-            endpoint="https://api.example.test/v1/tuning",
-            finetune_id="ft_123",
-            name="demo-ft",
-            rank=8,
-            max_retries=0,
-            retry_base_delay=0.01,
-            retry_max_delay=0.01,
-            timeout=0.01,
-        )
-        q0_started = threading.Event()
-        q1_started = threading.Event()
-        q2_started = threading.Event()
-        release_q0 = threading.Event()
+    def test_rollout_stream_stops_on_error(self):
+        call_count = [0]
+
+        def fake_rollouts(request):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise FinetuneAPIError("boom")
+            time.sleep(0.02)
+            return {
+                "request": {"skill": request.skill, "question": request.question},
+                "rollouts": [],
+            }
+
+        requests = [RolloutRequest(skill="query", question=f"q{i}") for i in range(10)]
+
+        with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
+            with self.assertRaises(FinetuneAPIError):
+                list(self.client.rollout_stream(requests, max_concurrency=2))
+
+    def test_rollout_stream_stops_before_extra_requests_on_error(self):
+        """stop.set() must happen before blocking on the queue so other
+        workers don't pull additional requests after the first failure."""
         started = []
-        result = {}
+        lock = threading.Lock()
 
-        def request_json_once(method, path, payload=None, query=None):
-            question = payload["request"]["question"]
-            started.append(question)
+        def fake_rollouts(request):
+            with lock:
+                started.append(request.question)
+            if request.question == "q1":
+                raise FinetuneAPIError("boom")
+            time.sleep(0.1)
+            return {
+                "request": {"skill": request.skill, "question": request.question},
+                "rollouts": [],
+            }
 
-            if question == "q0":
-                q0_started.set()
-                self.assertTrue(release_q0.wait(timeout=1))
-                return {"request": payload["request"], "rollouts": []}
+        requests = [RolloutRequest(skill="query", question=f"q{i}") for i in range(20)]
 
-            if question == "q1":
-                q1_started.set()
-                self.assertTrue(q0_started.wait(timeout=1))
-                raise urllib.error.URLError("boom")
+        with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
+            with self.assertRaises(FinetuneAPIError):
+                list(self.client.rollout_stream(
+                    requests, max_concurrency=2, buffer_size=1,
+                ))
 
-            q2_started.set()
-            return {"request": payload["request"], "rollouts": []}
+        # Workers should not have started many requests beyond the failure
+        self.assertLess(len(started), 6)
 
-        def run_batch_rollouts():
-            try:
-                client.batch_rollouts(
-                    [
-                        RolloutRequest(skill="query", question="q0"),
-                        RolloutRequest(skill="query", question="q1"),
-                        RolloutRequest(skill="query", question="q2"),
-                    ],
-                    max_concurrency=2,
-                )
-            except Exception as exc:
-                result["error"] = exc
+    def test_rollout_stream_surfaces_iterator_error(self):
+        def bad_iterator():
+            yield RolloutRequest(skill="query", question="q0")
+            raise RuntimeError("dataset failed")
 
-        worker = threading.Thread(target=run_batch_rollouts)
+        def fake_rollouts(request):
+            time.sleep(0.02)
+            return {
+                "request": {"skill": request.skill, "question": request.question},
+                "rollouts": [],
+            }
 
-        with mock.patch.object(client, "_request_json_once", side_effect=request_json_once):
-            worker.start()
-            self.assertTrue(q0_started.wait(timeout=1))
-            self.assertTrue(q1_started.wait(timeout=1))
-            worker.join(timeout=0.05)
-            self.assertTrue(worker.is_alive())
-            self.assertFalse(q2_started.is_set())
-
-            release_q0.set()
-            worker.join(timeout=1)
-
-        self.assertFalse(worker.is_alive())
-        self.assertIsInstance(result.get("error"), FinetuneAPIError)
-        self.assertEqual(len(started), 2)
-        self.assertCountEqual(started, ["q0", "q1"])
+        with mock.patch.object(self.client, "rollouts", side_effect=fake_rollouts):
+            with self.assertRaises(RuntimeError) as ctx:
+                list(self.client.rollout_stream(bad_iterator(), max_concurrency=2))
+            self.assertIn("dataset failed", str(ctx.exception))
 
     def test_list_checkpoints_pass_limit_through_without_local_validation(self):
         with mock.patch.object(

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -244,7 +244,6 @@ class FinetuneTests(unittest.TestCase):
             question="What country is this?",
             image=self.image,
             reasoning=False,
-            settings={"temperature": 0.0, "top_p": 1.0, "max_tokens": 16},
             targets=[{"answer": "United States"}],
         )
 
@@ -263,6 +262,7 @@ class FinetuneTests(unittest.TestCase):
         self.assertEqual(payload["groups"][1]["mode"], "sft")
         self.assertEqual(payload["groups"][1]["targets"], [{"answer": "United States"}])
         self.assertIn("image_url", payload["groups"][1]["request"])
+        self.assertNotIn("settings", payload["groups"][1]["request"])
 
     def test_train_step_hides_internal_metrics(self):
         rl_group = RLGroup(

--- a/test_finetune.py
+++ b/test_finetune.py
@@ -205,7 +205,7 @@ class FinetuneTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.client.detect_rollouts(FakeEncodedImage(), "vehicles")
 
-    def test_rlgroup_with_rewards_validates_length(self):
+    def test_rlgroup_rewards_assignment_validates_length(self):
         rl_group = RLGroup(
             skill="query",
             question="hi",
@@ -213,7 +213,7 @@ class FinetuneTests(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            rl_group.with_rewards([1.0, 0.0])
+            rl_group.rewards = [1.0, 0.0]
 
     def test_train_step_builds_mixed_rl_and_sft_payload(self):
         raw_rollout = _raw_rollout("query", {"answer": "A sign"})
@@ -293,7 +293,8 @@ class FinetuneTests(unittest.TestCase):
                 image=self.image,
                 question="What is happening?",
             )
-            result = self.client.train_step([rl_group.with_rewards([1.0])])
+            rl_group.rewards = [1.0]
+            result = self.client.train_step([rl_group])
 
         self.assertEqual(result["step"], 4)
         self.assertEqual(rl_group.rollouts, [{"answer": "People are socializing."}])
@@ -309,6 +310,20 @@ class FinetuneTests(unittest.TestCase):
             rollouts=[{"answer": "A photo"}],
             rewards=[1.0],
         )
+
+        with self.assertRaises(ValueError):
+            self.client.train_step([rl_group])
+
+    def test_train_step_rejects_mutated_rewards_length(self):
+        rl_group = RLGroup(
+            skill="query",
+            question="What is this?",
+            rollouts=[{"answer": "A photo"}],
+            rewards=[1.0],
+            _request_payload={"skill": "query", "question": "What is this?"},
+            _rollouts_payload=[_raw_rollout("query", {"answer": "A photo"})],
+        )
+        rl_group.rewards.append(0.0)
 
         with self.assertRaises(ValueError):
             self.client.train_step([rl_group])
@@ -439,7 +454,6 @@ class FinetuneTests(unittest.TestCase):
                 skill=group.skill,
                 question=group.question,
                 rollouts=[],
-                rewards=[1.0],
                 _request_payload={"skill": group.skill},
                 _rollouts_payload=[],
             )


### PR DESCRIPTION
## Summary

This PR adds finetuning to the Python SDK via `md.ft(...)`.

The final shape is intentionally close to the HTTP API and to the rest of this repo:

- one real `md.types.RolloutRequest` object for rollout inputs
- `ft.rollouts(...)` returns the raw `/rollouts` response
- `ft.batch_rollouts(...)` keeps the rollout concurrency helper and returns train-ready RL groups
- `ft.train_step(...)` takes HTTP-shaped RL/SFT group dicts instead of a second runtime object model
- synchronous public methods, with async used internally only for bounded rollout fanout
- `PIL.Image` inputs are still supported, like `md.vl(...)`
- no changes to `cloud_vl.py` or `photon_vl.py`

## Public API

- `md.ft(...) -> Finetune`
- `md.types.RolloutRequest(...)`
- `ft.rollouts(request) -> RolloutsResponse`
- `ft.batch_rollouts(requests, max_concurrency=4) -> list[RLGroup]`
- `ft.build_sft_group(skill=..., targets=..., ...) -> SFTGroup`
- `ft.train_step(groups, lr=0.002) -> TrainStepOutput`
- `ft.log_metrics(step, metrics) -> MetricsLogOutput`
- `ft.list_checkpoints()`, `ft.save_checkpoint()`, `ft.delete_checkpoint()`
- `ft.delete()` and `ft.model(step)`
- `examples/train_rps_query.py` as a minimal RL example

## Signatures, Defaults, And Returns

### `md.ft(...)`

```python
md.ft(
    api_key=None,
    *,
    name=None,
    rank=None,
    finetune_id=None,
    endpoint=DEFAULT_TUNING_ENDPOINT,
    max_retries=5,
    retry_base_delay=0.5,
    retry_max_delay=8.0,
    timeout=60.0,
) -> Finetune
```

- Create mode: `name` and `rank` are required.
- Bind mode: `finetune_id` is required and cannot be combined with `name` or `rank`.
- Returns a `Finetune` client bound to the created or fetched finetune.

### `md.types.RolloutRequest(...)`

```python
md.types.RolloutRequest(
    skill,
    num_rollouts=1,
    image=None,
    question=None,
    object=None,
    spatial_refs=None,
    reasoning=False,
    settings=None,
    ground_truth=None,
)
```

- `skill` is one of `"query"`, `"point"`, or `"detect"`.
- `num_rollouts` defaults to `1`.
- `settings=None` means the client sends no explicit sampling settings.
- Backend defaults from the HTTP API are:
  - `temperature=1.0`
  - `top_p=1.0`
  - `max_tokens=128` for `query`
  - `max_objects=50` for `point` and `detect`
- `image` accepts `PIL.Image` or `Base64EncodedImage`.

### `ft.rollouts(...)`

```python
ft.rollouts(request: md.types.RolloutRequest) -> md.types.RolloutsResponse
```

Returns the raw `/rollouts` response shape:

```python
{
    "request": {...},
    "rollouts": [...],
    "rewards": [...],  # optional
}
```

Each rollout stays in the HTTP shape. The skill-specific part is `rollout["output"]`.

```python
# query
{"answer": "People are smiling for a photo."}

# point
{"points": [{"x": 0.24, "y": 0.58}]}

# detect
{"objects": [{"x_min": 0.12, "y_min": 0.08, "x_max": 0.41, "y_max": 0.95}]}
```

### `ft.batch_rollouts(...)`

```python
ft.batch_rollouts(
    requests: Sequence[md.types.RolloutRequest],
    max_concurrency: int = 4,
) -> list[md.types.RLGroup]
```

- `max_concurrency` defaults to `4`.
- Returns one RL group per request, in order.
- Each returned group already has:
  - `"mode": "rl"`
  - `"request"`
  - `"rollouts"`
- If the rollout response included `rewards`, they are carried through.
- Users typically fill `group["rewards"]` before calling `train_step(...)`.

### `ft.build_sft_group(...)`

```python
ft.build_sft_group(
    *,
    skill,
    targets,
    image=None,
    question=None,
    object=None,
    reasoning=False,
    spatial_refs=None,
) -> md.types.SFTGroup
```

- `skill` is keyword-only to keep the call explicit.
- Returns the HTTP-shaped SFT group dict used by `train_step(...)`.
- This is the SFT-side convenience helper, analogous to RL using `batch_rollouts(...)` to produce train-step groups.

### `ft.train_step(...)`

```python
ft.train_step(
    groups: Sequence[md.types.RLGroup | md.types.SFTGroup],
    lr: float = 0.002,
) -> md.types.TrainStepOutput
```

- `groups` must be a non-empty list.
- `lr` defaults to `0.002`.
- RL groups must include `rewards`, and `len(rewards)` must match `len(rollouts)`.
- SFT groups are passed in the HTTP shape: `{"mode": "sft", "request": ..., "targets": ...}`.

Example `train_step()` output:

```python
{
    "step": 12,
    "applied": True,
    "kl": 0.031,
    "router_kl": 0.004,
    "grad_norm": 1.42,
    "reward_mean": 0.75,
    "reward_std": 0.18,
}
```

### Metrics And Checkpoints

```python
ft.log_metrics(step, metrics) -> MetricsLogOutput
ft.list_checkpoints(limit=50, cursor=None) -> CheckpointListOutput
ft.save_checkpoint() -> CheckpointInfo
ft.delete_checkpoint(step) -> None
ft.delete() -> None
ft.model(step) -> str
```

## Usage Examples

### Single RL rollout + train step

```python
import moondream as md

ft = md.ft(api_key=API_KEY, name="demo_ft", rank=8)

response = ft.rollouts(
    md.types.RolloutRequest(
        skill="query",
        image=image,
        question="What are the people doing?",
        num_rollouts=2,
        settings={"temperature": 0.7, "top_p": 0.9, "max_tokens": 32},
    )
)

rewards = [score_rollout(r["output"]["answer"]) for r in response["rollouts"]]

group: md.types.RLGroup = {
    "mode": "rl",
    "request": response["request"],
    "rollouts": response["rollouts"],
    "rewards": rewards,
}

step = ft.train_step([group], lr=0.001)
```

### Batched RL rollouts

```python
groups = ft.batch_rollouts(
    [
        md.types.RolloutRequest(
            skill="query",
            image=image,
            question="What are the people doing?",
            num_rollouts=2,
            settings={"temperature": 0.7, "top_p": 0.9, "max_tokens": 32},
        ),
        md.types.RolloutRequest(
            skill="query",
            image=image,
            question="How many people are there?",
            num_rollouts=2,
            settings={"temperature": 0.7, "top_p": 0.9, "max_tokens": 32},
        ),
    ],
    max_concurrency=2,
)

for group in groups:
    group["rewards"] = [
        score_rollout(r["output"]["answer"]) for r in group["rollouts"]
    ]

step = ft.train_step(groups, lr=0.001)
```

Behavior:

- order is preserved
- at most `max_concurrency` rollout requests are in flight at once
- if one request ultimately fails after retries, no new queued requests are started
- already-started requests are drained before the first error is raised

### SFT train step

```python
sft_group = ft.build_sft_group(
    skill="query",
    image=image,
    question="What is happening?",
    targets=[{"answer": "People are smiling for a photo."}],
)

step = ft.train_step([sft_group])
```

### Metrics And Checkpoints

```python
metrics = ft.log_metrics(
    step=step["step"],
    metrics={
        "eval/accuracy": 0.81,
        "eval/token_f1": 0.64,
    },
)

checkpoint = ft.save_checkpoint()
checkpoints = ft.list_checkpoints()
model_id = ft.model(checkpoint["step"])
```

The repo also includes `examples/train_rps_query.py`, a simple rock/paper/scissors RL finetuning example using the public SDK surface above.

## Retry / Backoff Policy

Retried:

- `408`
- `429`
- `500`, `502`, `503`, `504`, `524`
- `URLError`
- `TimeoutError` and `socket.timeout`

Not retried:

- `400`
- `401`
- `403`
- `404`
- `409`
- `410`
- other non-transient request/state/auth errors

Backoff behavior:

- exponential backoff with jitter
- configurable with `max_retries`, `retry_base_delay`, `retry_max_delay`, and `timeout`
- `train_step()` uses `max_retries=0` because it is state-mutating

## Validation

Local:

- `python -m py_compile moondream/types.py moondream/finetune.py test_finetune.py examples/train_rps_query.py`
- `python -m unittest -v test_finetune.py`
- `python examples/train_rps_query.py --help`

Latest local run: 24 tests passed.

Live staging:

- create/delete succeeded on the current branch
- direct `RolloutRequest -> rollouts()` reached staging and then timed out waiting on `/rollouts`
- the example script also reached finetune creation and then stalled in the rollout path while staging was unstable
