### PR TITLE
Bump to 1.2.0; Photon 0.3.0 (Apple Silicon + Windows + Blackwell + Jetson Thor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Moondream Python Client Library
 
-Official Python client library for Moondream, a fast multi-function VLM. This client can target [Moondream Cloud](https://moondream.ai/cloud) or run locally on GPU via Photon.
+Official Python client library for Moondream, a fast multi-function VLM. This client can target [Moondream Cloud](https://moondream.ai/cloud) or run locally via Photon — on NVIDIA GPUs (Linux x86_64 / aarch64 or Windows) or Apple Silicon Macs.
 
 ## Capabilities
 
@@ -27,7 +27,7 @@ pip install moondream
 Choose how you want to run Moondream:
 
 1. **Moondream Cloud** — Get an API key from the [cloud console](https://moondream.ai/c/cloud/api-keys)
-2. **Moondream Photon** — High-performance local GPU inference engine (requires an NVIDIA GPU and an API key)
+2. **Moondream Photon** — High-performance local inference engine on NVIDIA GPUs (Linux / Windows) or Apple Silicon Macs (macOS 13+, Python 3.12). Requires an API key.
 
 ```python
 import moondream as md
@@ -36,7 +36,7 @@ from PIL import Image
 # Initialize with Moondream Cloud
 model = md.vl(api_key="<your-api-key>")
 
-# Or initialize with local GPU inference (Photon)
+# Or initialize with local inference (Photon — NVIDIA GPU or Apple Silicon)
 model = md.vl(api_key="<your-api-key>", local=True)
 
 # Load an image
@@ -61,7 +61,7 @@ for chunk in model.caption(image, stream=True)["caption"]:
 
 ```python
 model = md.vl(api_key="<your-api-key>")                        # Cloud
-model = md.vl(api_key="<your-api-key>", local=True)            # Photon (local GPU)
+model = md.vl(api_key="<your-api-key>", local=True)            # Photon (local: NVIDIA GPU or Apple Silicon)
 model = md.vl(api_key="<your-api-key>", model="moondream3-preview/ft_id@step")  # Finetune
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "moondream"
-version = "1.1.0"
+version = "1.2.0"
 description = "Official Python client for Moondream, a fast and efficient vision language model."
 authors = [ "M87 Labs <contact@moondream.ai>",]
 readme = "README.md"
@@ -20,4 +20,4 @@ reportMissingParameterType = false
 [tool.poetry.dependencies]
 python = "^3.10"
 pillow = "^10.4.0"
-kestrel = "^0.2.1"
+kestrel = "^0.3.0"


### PR DESCRIPTION
## Summary
- Bump moondream client 1.1.0 → 1.2.0.
- Bump Photon (kestrel) pin \`^0.2.1\` → \`^0.3.0\`. The poetry caret on 0.2.x excluded 0.3.0, so without this users on 1.1.0 don't get the new platforms when they upgrade kestrel manually.
- README updated: lead description, Quick Start \`local=True\` comments, Photon bullet under "Choose how you want to run Moondream" all reflect that Photon now runs on Apple Silicon as well as NVIDIA.

## What kestrel 0.3.0 unlocks for moondream client users
- **Apple Silicon Macs** (macOS 13+, Python 3.12): \`md.vl(local=True)\` now works on M-series Macs with native Metal kernels.
- **Windows AMD64**: \`md.vl(local=True)\` works natively on Windows with NVIDIA GPUs (no WSL).
- **NVIDIA Blackwell**: B200 + RTX PRO 6000 are first-class targets.
- **Jetson Thor (JetPack 7)**: supported alongside Orin (JetPack 6) from the same wheel.
- **Faster on existing NVIDIA hardware** — internal kernel-dispatch overhaul + per-arch retunes.

See the [kestrel 0.3.0 CHANGELOG](https://github.com/m87-labs/kestrel/blob/main/CHANGELOG.md#030--2026-05-01) for the full story.

## Test plan
- [ ] \`pip install moondream==1.2.0\` resolves to kestrel 0.3.0.
- [ ] \`md.vl(api_key=..., local=True)\` smoke test on at least one NVIDIA host (Linux x86_64) — same call site as before, no API change.