### PR TITLE
README: drop the Python-3.12-on-macOS caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install moondream
 Choose how you want to run Moondream:
 
 1. **Moondream Cloud** — Get an API key from the [cloud console](https://moondream.ai/c/cloud/api-keys)
-2. **Moondream Photon** — High-performance local inference engine on NVIDIA GPUs (Linux / Windows) or Apple Silicon Macs (macOS 13+, Python 3.12). Requires an API key.
+2. **Moondream Photon** — High-performance local inference engine on NVIDIA GPUs (Linux / Windows) or Apple Silicon Macs (macOS 13+). Requires an API key.
 
 ```python
 import moondream as md


### PR DESCRIPTION
kestrel-kernels 0.3.2 macOS arm64 wheels now ship cp310-cp314, so Photon on Apple Silicon no longer requires Python 3.12 specifically.