### PR TITLE
Auto-detect Photon local device

### DIFF
--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -7,6 +7,7 @@ import threading
 from io import BytesIO
 from typing import Generator, List, Literal, Optional, Union
 
+import torch
 from PIL import Image
 
 from .types import (
@@ -21,6 +22,18 @@ from .types import (
     SegmentOutput,
     SpatialRef,
 )
+
+
+def _default_photon_device() -> str:
+    """Choose the local Photon device when the caller does not specify one."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
+    raise RuntimeError(
+        "Photon local inference needs a supported accelerator, but neither "
+        "CUDA nor Apple Silicon MPS is available in this Python environment."
+    )
 
 
 def _image_to_bytes(image: Union[Image.Image, EncodedImage]) -> bytes:
@@ -136,9 +149,10 @@ class PhotonVL(VLM):
         model: str = "moondream3-preview",
         max_batch_size: int = 4,
         kv_cache_pages: Optional[int] = None,
-        device: str = "cuda",
+        device: Optional[str] = None,
     ):
         base_model, self._adapter = _parse_model(model)
+        device = _default_photon_device() if device is None else device
         self._engine, self._loop, self._thread = _get_or_create_engine(
             base_model, max_batch_size, kv_cache_pages, device, api_key=api_key
         )


### PR DESCRIPTION
## Summary

- default Photon local device selection to CUDA when available, otherwise Apple Silicon MPS
- raise a clear local-inference error when neither supported accelerator is available

## Root Cause

The local Photon client hardcoded `device="cuda"`, so Apple Silicon users entered Kestrel's CUDA validation path and saw a misleading CPU-only PyTorch reinstall error instead of using MPS.

## Validation

- `/home/vikhyat/code/md-clients/moondream-python/.venv/bin/python -m unittest discover`