### PR TITLE
Prepare 1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.2.1
+
+- Auto-detect the Photon local inference device when `device` is not specified,
+  choosing CUDA when available and Apple Silicon MPS otherwise, while preserving
+  explicit device overrides.
+- Removed the outdated README caveat that limited Apple Silicon local inference
+  to Python 3.12.
+
+## 1.2.0
+
+- Added `md.ft(...)`, a finetuning client for creating or resuming finetunes,
+  generating rollouts, applying RL and SFT train steps, logging metrics, and
+  managing checkpoints.
+- Added typed finetuning request and response models under `md.types`, including
+  rollout, training, metrics, checkpoint, ground-truth, RL group, and SFT group
+  types.
+- Added `rollout_stream(...)` for concurrent background rollout generation with
+  context passthrough, so training can proceed while the next rollouts are in
+  flight.
+- Added `examples/train_rps_query.py`, an end-to-end rock/paper/scissors
+  finetuning example.
+- Hardened finetuning HTTP requests with retry/backoff handling for transient
+  network and server errors.
+- Changed the default finetune `train_step` learning rate to 2e-4.
+- Upgraded the Photon local inference engine to v0.3.0, with local inference
+  supported on NVIDIA GPUs and Apple Silicon Macs.
+
 ## 1.1.0
 
 - Upgraded Photon engine to v0.2.1 — up to ~55% throughput improvement on H100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "moondream"
-version = "1.2.0"
+version = "1.2.1"
 description = "Official Python client for Moondream, a fast and efficient vision language model."
 authors = [ "M87 Labs <contact@moondream.ai>",]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump the Python package version to 1.2.1.
- Add changelog notes for the 1.2.1 Photon device auto-detection patch.
- Backfill the missing 1.2.0 changelog entry covering the finetuning SDK, rollout streaming, retry hardening, examples, and Photon 0.3.0 upgrade.

## Validation

- `uv run --with pytest pytest`