### PR TITLE
Prepare moondream 1.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.2
+
+- Upgraded the Photon local inference engine to `kestrel 0.4.0`. On Apple
+  Silicon, local installs now work across supported PyTorch 2.9-2.12 builds
+  instead of being tied to one PyTorch minor version.
+
 ## 1.2.1
 
 - Auto-detect the Photon local inference device when `device` is not specified,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "moondream"
-version = "1.2.1"
+version = "1.2.2"
 description = "Official Python client for Moondream, a fast and efficient vision language model."
 authors = [ "M87 Labs <contact@moondream.ai>",]
 readme = "README.md"
@@ -20,4 +20,4 @@ reportMissingParameterType = false
 [tool.poetry.dependencies]
 python = "^3.10"
 pillow = "^10.4.0"
-kestrel = "^0.3.0"
+kestrel = "^0.4.0"


### PR DESCRIPTION
## Summary

- Bump the package version to `1.2.2`.
- Update Photon local inference to require `kestrel >=0.4.0,<0.5.0`.
- Add a customer-facing changelog note for Apple Silicon installs across supported PyTorch 2.9-2.12 builds.

## Validation

- `git diff --check -- pyproject.toml CHANGELOG.md`
- `python -m unittest test_finetune.py`
- Built a no-deps wheel and confirmed `Requires-Dist: kestrel (>=0.4.0,<0.5.0)`.