### PR TITLE
Route failed CUDA init to Kestrel diagnostics

### DIFF
--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -28,6 +28,11 @@ def _default_photon_device() -> str:
     """Choose the local Photon device when the caller does not specify one."""
     if torch.cuda.is_available():
         return "cuda"
+    if torch.backends.cuda.is_built():
+        # CUDA was installed but failed to initialize. Let Kestrel validate the
+        # explicit CUDA device so users get the same driver/runtime diagnostic
+        # as they would when passing device="cuda" themselves.
+        return "cuda"
     if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         return "mps"
     raise RuntimeError(


### PR DESCRIPTION
## Summary

- Keep Photon's automatic device selection on CUDA when PyTorch is CUDA-built but CUDA initialization fails.
- Let Kestrel validate the explicit CUDA device so users see the detailed driver/runtime diagnostic instead of the generic no-accelerator message.

## Why

The user-facing failure was happening before Kestrel had a chance to explain the real CUDA initialization problem. This keeps diagnostics centralized in Kestrel and avoids duplicating runtime compatibility logic in the client.

## Validation

- `git diff --check`
- `python -m py_compile moondream/photon_vl.py`