### PR TITLE
Release Moondream 2.0 with Kestrel 0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
+__pycache__/
+.venv/
+dist/
 pip_test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   supported NVIDIA GPUs, with the regular optimized path retained as a
   transparent fallback.
 - Added local inference support for Moondream 3.1 9B A2B.
+- Photon can now run every model bundled with Kestrel 0.5, including the
+  supported Qwen 3.5, Qwen 3.6, and Gemma 4 variants.
 - Improved responsiveness under large request bursts and made startup and
   out-of-memory failures safer for concurrent workloads.
 - Local sampling settings are now forwarded consistently, including

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   out-of-memory failures safer for concurrent workloads.
 - Local sampling settings are now forwarded consistently, including
   temperature, top-p, output limits, and spatial object limits.
+- Added multi-turn chat and spatial-reference guidance consistently across
+  Cloud and Photon local inference.
+- Photon clients can now release shared local engine resources deterministically
+  with `close()` or a context manager.
 - Pinned Kestrel exactly so every `moondream 2.0.0` installation uses the
   engine and bundled-kernel release validated with this client.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.0.0
+
+- Upgraded Photon local inference to `kestrel 0.5.0`. Moondream 2 and
+  Moondream 3 now automatically use bundled whole-model decode kernels on
+  supported NVIDIA GPUs, with the regular optimized path retained as a
+  transparent fallback.
+- Added local inference support for Moondream 3.1 9B A2B.
+- Improved responsiveness under large request bursts and made startup and
+  out-of-memory failures safer for concurrent workloads.
+- Local sampling settings are now forwarded consistently, including
+  temperature, top-p, output limits, and spatial object limits.
+- Pinned Kestrel exactly so every `moondream 2.0.0` installation uses the
+  engine and bundled-kernel release validated with this client.
+
+See the [Kestrel 0.5.0 changelog](https://github.com/m87-labs/kestrel/blob/main/CHANGELOG.md#050--2026-08-02)
+for the complete engine release notes.
+
 ## 1.3.0
 
 - Upgraded the Photon local inference engine to `kestrel 0.4.2`; see the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Moondream goes beyond the typical VLM "query" ability to include more visual fun
 
 Try it out on [Moondream's playground](https://moondream.ai/playground).
 
+## Photon Models
+
+Photon local inference includes all models bundled with Kestrel 0.5:
+
+| Family | Models |
+|--------|--------|
+| Moondream | Moondream 2, Moondream 3, Moondream 3.1 9B A2B |
+| Qwen 3.5 | 0.8B, 2B, 4B, 9B, 27B, and 35B-A3B; Base variants where published |
+| Qwen 3.6 | 27B and 35B-A3B; BF16 and FP8 checkpoints |
+| Gemma 4 | E2B, E4B, and 31B base/instruction variants |
+
+Use `md.photon_models()` to inspect the exact registered identifiers in the installed
+release. The returned client reports `model_id`, `tasks`, and
+`supports(task)` without requiring a Kestrel import.
+Existing `md.vl(local=True, ...)` calls remain supported and delegate to
+`md.photon(...)`.
+
 ## Installation
 
 ```bash
@@ -37,8 +54,8 @@ from PIL import Image
 # Initialize with Moondream Cloud
 model = md.vl(api_key="<your-api-key>")
 
-# Or initialize with local inference (Photon — NVIDIA GPU or Apple Silicon)
-model = md.vl(local=True)
+# Or initialize Photon local inference (NVIDIA GPU or Apple Silicon)
+model = md.photon()
 
 # Load an image
 image = Image.open("path/to/image.jpg")
@@ -70,12 +87,14 @@ print(chat["message"]["content"])
 
 ```python
 model = md.vl(api_key="<your-api-key>")                        # Cloud
-model = md.vl(local=True)                                      # Photon (local: NVIDIA GPU or Apple Silicon)
+model = md.photon()                                            # Photon with Moondream 3
 model = md.vl(api_key="<your-api-key>", model="moondream3-preview/ft_id@step")  # Finetune
+qwen = md.photon("Qwen/Qwen3.5-4B")
+gemma = md.photon("google/gemma-4-E2B-it")
 ```
 
 Photon clients share matching local engines. Call `model.close()` when an
-application is finished with a client, or use `with md.vl(local=True) as model:`
+application is finished with a client, or use `with md.photon() as model:`
 for deterministic GPU and worker cleanup.
 
 ### Methods

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install moondream
 Choose how you want to run Moondream:
 
 1. **Moondream Cloud** — Get an API key from the [cloud console](https://moondream.ai/c/cloud/api-keys)
-2. **Moondream Photon** — High-performance local inference engine on NVIDIA GPUs (Linux / Windows) or Apple Silicon Macs (macOS 13+). Requires an API key.
+2. **Moondream Photon** — High-performance local inference engine on NVIDIA GPUs (Linux / Windows) or Apple Silicon Macs (macOS 13+). Base models run locally without an API key; an API key is only needed for finetuned models.
 
 ```python
 import moondream as md
@@ -37,7 +37,7 @@ from PIL import Image
 model = md.vl(api_key="<your-api-key>")
 
 # Or initialize with local inference (Photon — NVIDIA GPU or Apple Silicon)
-model = md.vl(api_key="<your-api-key>", local=True)
+model = md.vl(local=True)
 
 # Load an image
 image = Image.open("path/to/image.jpg")
@@ -61,7 +61,7 @@ for chunk in model.caption(image, stream=True)["caption"]:
 
 ```python
 model = md.vl(api_key="<your-api-key>")                        # Cloud
-model = md.vl(api_key="<your-api-key>", local=True)            # Photon (local: NVIDIA GPU or Apple Silicon)
+model = md.vl(local=True)                                      # Photon (local: NVIDIA GPU or Apple Silicon)
 model = md.vl(api_key="<your-api-key>", model="moondream3-preview/ft_id@step")  # Finetune
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ for chunk in model.query(image, "What's in this image?", stream=True)["answer"]:
 
 ---
 
-#### `chat(messages, stream=False, reasoning=False)`
+#### `chat(messages, stream=False, reasoning=None)`
 
 Continue an OpenAI-style multi-turn conversation. Message content can be text
-or a list of `text` and base64 `image_url` parts.
+or a list of `text` and base64 `image_url` parts. When `reasoning` is omitted,
+the selected model or Cloud service supplies its default.
 
 ```python
 result = model.chat([

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Moondream goes beyond the typical VLM "query" ability to include more visual fun
 |--------|-------------|
 | `caption` | Generate descriptive captions for images |
 | `query` | Ask questions about image content |
+| `chat` | Continue multi-turn conversations with text and images |
 | `detect` | Find bounding boxes around objects in images |
 | `point` | Identify the center location of specified objects |
 | `segment` | Generate an SVG path segmentation mask for objects |
@@ -53,6 +54,14 @@ print("Answer:", answer)
 # Stream the response
 for chunk in model.caption(image, stream=True)["caption"]:
     print(chunk, end="", flush=True)
+
+# Multi-turn chat accepts OpenAI-style messages
+chat = model.chat([
+    {"role": "user", "content": "My name is Alice."},
+    {"role": "assistant", "content": "Nice to meet you, Alice!"},
+    {"role": "user", "content": "What is my name?"},
+])
+print(chat["message"]["content"])
 ```
 
 ## API Reference
@@ -64,6 +73,10 @@ model = md.vl(api_key="<your-api-key>")                        # Cloud
 model = md.vl(local=True)                                      # Photon (local: NVIDIA GPU or Apple Silicon)
 model = md.vl(api_key="<your-api-key>", model="moondream3-preview/ft_id@step")  # Finetune
 ```
+
+Photon clients share matching local engines. Call `model.close()` when an
+application is finished with a client, or use `with md.vl(local=True) as model:`
+for deterministic GPU and worker cleanup.
 
 ### Methods
 
@@ -88,7 +101,7 @@ for chunk in model.caption(image, stream=True)["caption"]:
 
 ---
 
-#### `query(image, question, stream=False)`
+#### `query(image, question, stream=False, spatial_refs=None)`
 
 Ask a question about an image.
 
@@ -96,6 +109,7 @@ Ask a question about an image.
 - `image` — `Image.Image` or `EncodedImage`
 - `question` — `str`
 - `stream` — `bool` (default: `False`)
+- `spatial_refs` — optional point or box hints, normalized to 0-1
 
 **Returns:** `QueryOutput` — `{"answer": str | Generator}`
 
@@ -104,6 +118,28 @@ answer = model.query(image, "What's in this image?")["answer"]
 
 # With streaming
 for chunk in model.query(image, "What's in this image?", stream=True)["answer"]:
+    print(chunk, end="", flush=True)
+```
+
+---
+
+#### `chat(messages, stream=False, reasoning=False)`
+
+Continue an OpenAI-style multi-turn conversation. Message content can be text
+or a list of `text` and base64 `image_url` parts.
+
+```python
+result = model.chat([
+    {"role": "user", "content": "Remember that my favorite color is green."},
+    {"role": "assistant", "content": "Got it."},
+    {"role": "user", "content": "What is my favorite color?"},
+])
+print(result["message"]["content"])
+
+for chunk in model.chat(
+    [{"role": "user", "content": "Write a short poem about the moon."}],
+    stream=True,
+)["message"]:
     print(chunk, end="", flush=True)
 ```
 
@@ -125,13 +161,14 @@ objects = model.detect(image, "car")["objects"]
 
 ---
 
-#### `point(image, object)`
+#### `point(image, object, spatial_refs=None)`
 
 Get coordinates of specific objects in an image.
 
 **Parameters:**
 - `image` — `Image.Image` or `EncodedImage`
 - `object` — `str`
+- `spatial_refs` — optional point or box hints, normalized to 0-1
 
 **Returns:** `PointOutput` — `{"points": List[Point]}`
 

--- a/moondream/__init__.py
+++ b/moondream/__init__.py
@@ -10,6 +10,29 @@ __version__ = _pkg_version("moondream")
 DEFAULT_ENDPOINT = "https://api.moondream.ai/v1"
 
 
+def photon_models() -> list[str]:
+    """Return the models available to Photon local inference."""
+    from kestrel.models import known_models
+
+    return known_models()
+
+
+def photon(
+    model: str = "moondream3-preview",
+    *,
+    api_key: Optional[str] = None,
+    **runtime_config,
+):
+    """Create a local Photon model backed by Kestrel's bundled runtime."""
+    from .photon_vl import PhotonVL
+
+    return PhotonVL(
+        api_key=api_key,
+        model=model,
+        **runtime_config,
+    )
+
+
 def vl(
     api_key: Optional[str] = None,
     endpoint: Optional[str] = DEFAULT_ENDPOINT,
@@ -22,7 +45,7 @@ def vl(
     Args:
         api_key (str): Your API key for the remote (cloud) API.
         endpoint (str): The endpoint which you would like to call. Local is http://localhost:2020/v1 by default.
-        local (bool): If True, use local GPU inference via Photon instead of the cloud API.
+        local (bool): If True, delegate to ``photon()`` instead of the Cloud API.
         **kwargs: Additional arguments forwarded to the selected backend. In local mode,
             arguments other than ``model`` are passed directly to Kestrel's
             ``RuntimeConfig``.
@@ -31,10 +54,10 @@ def vl(
         An instance of CloudVL or PhotonVL.
     """
     if local:
-        from .photon_vl import PhotonVL
-        return PhotonVL(api_key=api_key, **kwargs)
+        model = kwargs.pop("model", "moondream3-preview")
+        return photon(model, api_key=api_key, **kwargs)
     model = kwargs.pop("model", None)
     return CloudVL(api_key=api_key, endpoint=endpoint, model=model, **kwargs)
 
 
-__all__ = ["ft", "vl", "__version__"]
+__all__ = ["ft", "photon", "photon_models", "vl", "__version__"]

--- a/moondream/__init__.py
+++ b/moondream/__init__.py
@@ -23,8 +23,9 @@ def vl(
         api_key (str): Your API key for the remote (cloud) API.
         endpoint (str): The endpoint which you would like to call. Local is http://localhost:2020/v1 by default.
         local (bool): If True, use local GPU inference via Photon instead of the cloud API.
-        **kwargs: Additional arguments forwarded to the backend (e.g. model, max_batch_size,
-            kv_cache_pages, device for local mode).
+        **kwargs: Additional arguments forwarded to the selected backend. In local mode,
+            arguments other than ``model`` are passed directly to Kestrel's
+            ``RuntimeConfig``.
 
     Returns:
         An instance of CloudVL or PhotonVL.

--- a/moondream/cloud_vl.py
+++ b/moondream/cloud_vl.py
@@ -10,6 +10,8 @@ from .types import (
     VLM,
     Base64EncodedImage,
     CaptionOutput,
+    ChatMessage,
+    ChatOutput,
     DetectOutput,
     EncodedImage,
     PointOutput,
@@ -120,6 +122,7 @@ class CloudVL(VLM):
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
         reasoning: bool = False,
+        spatial_refs: Optional[list[SpatialRef]] = None,
     ) -> QueryOutput:
         if question is None:
             raise ValueError("question parameter is required")
@@ -138,6 +141,8 @@ class CloudVL(VLM):
             payload["settings"] = settings
         if reasoning:
             payload["reasoning"] = reasoning
+        if spatial_refs is not None:
+            payload["spatial_refs"] = spatial_refs
 
         data = json.dumps(payload).encode("utf-8")
         headers = {
@@ -161,6 +166,72 @@ class CloudVL(VLM):
             if "reasoning" in result and result["reasoning"] is not None:
                 output["reasoning"] = result["reasoning"]
             return output
+
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        stream: bool = False,
+        settings: Optional[SamplingSettings] = None,
+        reasoning: bool = False,
+    ) -> ChatOutput:
+        payload = {
+            "model": self.model or "moondream3-preview",
+            "messages": messages,
+            "stream": stream,
+            "reasoning": reasoning,
+        }
+        if settings is not None:
+            if "temperature" in settings:
+                payload["temperature"] = settings["temperature"]
+            if "top_p" in settings:
+                payload["top_p"] = settings["top_p"]
+            if "max_tokens" in settings:
+                payload["max_completion_tokens"] = settings["max_tokens"]
+
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": f"moondream-python/{__version__}",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        req = urllib.request.Request(
+            f"{self.endpoint}/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+        )
+
+        if stream:
+            return {"message": self._stream_chat_response(req)}
+
+        with urllib.request.urlopen(req) as response:
+            result = json.loads(response.read().decode("utf-8"))
+        choice = result["choices"][0]
+        return {
+            "message": choice["message"],
+            "finish_reason": choice.get("finish_reason", "stop"),
+        }
+
+    def _stream_chat_response(self, req):
+        with urllib.request.urlopen(req) as response:
+            for line in response:
+                if not line:
+                    continue
+                line = line.decode("utf-8").strip()
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    return
+                try:
+                    event = json.loads(data)
+                except json.JSONDecodeError as exc:
+                    raise ValueError("Failed to parse chat stream response.") from exc
+                choices = event.get("choices", [])
+                if not choices:
+                    continue
+                chunk = choices[0].get("delta", {}).get("content")
+                if chunk:
+                    yield chunk
 
     def detect(
         self,
@@ -200,12 +271,15 @@ class CloudVL(VLM):
         image: Union[Image.Image, EncodedImage],
         object: str,
         settings: Optional[SamplingSettings] = None,
+        spatial_refs: Optional[list[SpatialRef]] = None,
     ) -> PointOutput:
         encoded_image = self.encode_image(image)
         payload = {
             "image_url": encoded_image.image_url,
             "object": object,
         }
+        if spatial_refs is not None:
+            payload["spatial_refs"] = spatial_refs
         if self.model is not None:
             payload["model"] = self.model
         if settings is not None:

--- a/moondream/cloud_vl.py
+++ b/moondream/cloud_vl.py
@@ -172,14 +172,15 @@ class CloudVL(VLM):
         messages: list[ChatMessage],
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
-        reasoning: bool = False,
+        reasoning: Optional[bool] = None,
     ) -> ChatOutput:
         payload = {
             "model": self.model or "moondream3-preview",
             "messages": messages,
             "stream": stream,
-            "reasoning": reasoning,
         }
+        if reasoning is not None:
+            payload["reasoning"] = reasoning
         if settings is not None:
             if "temperature" in settings:
                 payload["temperature"] = settings["temperature"]
@@ -208,7 +209,7 @@ class CloudVL(VLM):
         choice = result["choices"][0]
         return {
             "message": choice["message"],
-            "finish_reason": choice.get("finish_reason", "stop"),
+            "finish_reason": choice.get("finish_reason") or "stop",
         }
 
     def _stream_chat_response(self, req):

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -1,7 +1,9 @@
 """Local GPU inference backend using kestrel (Photon)."""
 
 import asyncio
+import atexit
 import base64
+import json
 import os
 import queue
 import threading
@@ -15,12 +17,15 @@ from .types import (
     VLM,
     Base64EncodedImage,
     CaptionOutput,
+    ChatMessage,
+    ChatOutput,
     DetectOutput,
     EncodedImage,
     PointOutput,
     QueryOutput,
     SamplingSettings,
     SegmentOutput,
+    SegmentStreamOutput,
     SpatialRef,
 )
 
@@ -91,8 +96,34 @@ def _build_settings(
 # PhotonVL instances differing only by adapter share an engine. Credentials
 # remain isolated because the engine owns the adapter provider for its key.
 
-_engine_cache: dict[tuple, tuple] = {}  # key -> (engine, loop, thread)
+_engine_cache: dict[tuple, tuple] = {}  # key -> (engine, loop, thread, refs)
 _cache_lock = threading.Lock()
+
+
+def _stop_engine(engine, loop, thread) -> None:
+    if loop.is_running():
+        try:
+            asyncio.run_coroutine_threadsafe(
+                engine.shutdown(), loop
+            ).result(timeout=30)
+        except Exception:
+            pass
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=30)
+
+
+def _shutdown_cached_engines() -> None:
+    """Stop shared engines before Python tears down CUDA and worker threads."""
+    with _cache_lock:
+        entries = list(_engine_cache.values())
+        _engine_cache.clear()
+
+    for engine, loop, thread, _refs in entries:
+        _stop_engine(engine, loop, thread)
+
+
+atexit.register(_shutdown_cached_engines)
 
 
 def _get_or_create_engine(
@@ -100,7 +131,7 @@ def _get_or_create_engine(
     runtime_config: dict,
     api_key: Optional[str] = None,
 ):
-    """Return a shared (engine, loop, thread) for the given config."""
+    """Acquire a shared engine for the given config."""
     effective_api_key = (
         api_key if api_key is not None else os.environ.get("MOONDREAM_API_KEY")
     )
@@ -108,7 +139,9 @@ def _get_or_create_engine(
 
     with _cache_lock:
         if key in _engine_cache:
-            return _engine_cache[key]
+            engine, loop, thread, refs = _engine_cache[key]
+            _engine_cache[key] = (engine, loop, thread, refs + 1)
+            return engine, loop, thread, key
 
     # Import kestrel lazily so non-GPU environments can still import moondream.
     from kestrel import InferenceEngine
@@ -132,18 +165,41 @@ def _get_or_create_engine(
         thread.join()
         raise
 
-    entry = (engine, loop, thread)
+    loser = None
     with _cache_lock:
         # Another thread may have raced us; use the winner.
         if key in _engine_cache:
-            # Shut down the engine we just created.
-            asyncio.run_coroutine_threadsafe(engine.shutdown(), loop).result()
-            loop.call_soon_threadsafe(loop.stop)
-            thread.join()
-            return _engine_cache[key]
-        _engine_cache[key] = entry
+            winner_engine, winner_loop, winner_thread, refs = _engine_cache[key]
+            _engine_cache[key] = (
+                winner_engine,
+                winner_loop,
+                winner_thread,
+                refs + 1,
+            )
+            loser = (engine, loop, thread)
+        else:
+            _engine_cache[key] = (engine, loop, thread, 1)
 
-    return entry
+    if loser is not None:
+        _stop_engine(*loser)
+        return winner_engine, winner_loop, winner_thread, key
+
+    return engine, loop, thread, key
+
+
+def _release_engine(key: tuple) -> None:
+    entry = None
+    with _cache_lock:
+        cached = _engine_cache.get(key)
+        if cached is None:
+            return
+        engine, loop, thread, refs = cached
+        if refs > 1:
+            _engine_cache[key] = (engine, loop, thread, refs - 1)
+            return
+        entry = _engine_cache.pop(key)
+
+    _stop_engine(*entry[:3])
 
 
 class PhotonVL(VLM):
@@ -159,9 +215,21 @@ class PhotonVL(VLM):
         base_model, self._adapter = _parse_model(model)
         if runtime_config.get("device") is None:
             runtime_config["device"] = _default_photon_device()
-        self._engine, self._loop, self._thread = _get_or_create_engine(
-            base_model, runtime_config, api_key=api_key
-        )
+        (
+            self._engine,
+            self._loop,
+            self._thread,
+            self._engine_key,
+        ) = _get_or_create_engine(base_model, runtime_config, api_key=api_key)
+        self._model = self._engine.model()
+
+    def close(self) -> None:
+        """Release this client's reference to its shared local engine."""
+        key = self._engine_key
+        if key is None:
+            return
+        self._engine_key = None
+        _release_engine(key)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -181,6 +249,43 @@ class PhotonVL(VLM):
                 async for update in stream:
                     q.put(update.text)
                 q.put(None)  # sentinel
+            except Exception as exc:
+                q.put(exc)
+
+        asyncio.run_coroutine_threadsafe(_consume(), self._loop)
+
+        while True:
+            item = q.get()
+            if item is None:
+                return
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    def _segment_stream_to_generator(self, coro) -> SegmentStreamOutput:
+        """Bridge Kestrel's segment stream into the public update shape."""
+        q: queue.Queue = queue.Queue()
+
+        async def _consume():
+            try:
+                stream = await coro
+                async for update in stream:
+                    text = update.text
+                    if text.startswith("__BBOX__"):
+                        q.put({"bbox": json.loads(text[len("__BBOX__"):])})
+                    elif text:
+                        q.put({"chunk": text})
+
+                result = await stream.result()
+                segment = result.output["segments"][0]
+                q.put(
+                    {
+                        "path": segment["svg_path"],
+                        "bbox": segment.get("bbox"),
+                        "completed": True,
+                    }
+                )
+                q.put(None)
             except Exception as exc:
                 q.put(exc)
 
@@ -234,8 +339,8 @@ class PhotonVL(VLM):
 
         if stream:
             gen = self._stream_to_generator(
-                self._engine.caption(
-                    image_bytes,
+                self._model.caption(
+                    image=image_bytes,
                     length=length,
                     stream=True,
                     settings=engine_settings,
@@ -244,8 +349,8 @@ class PhotonVL(VLM):
             return {"caption": gen}
 
         result = self._run(
-            self._engine.caption(
-                image_bytes,
+            self._model.caption(
+                image=image_bytes,
                 length=length,
                 stream=False,
                 settings=engine_settings,
@@ -260,6 +365,7 @@ class PhotonVL(VLM):
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
         reasoning: bool = False,
+        spatial_refs: Optional[List[SpatialRef]] = None,
     ) -> QueryOutput:
         if question is None:
             raise ValueError("question parameter is required")
@@ -269,10 +375,11 @@ class PhotonVL(VLM):
 
         if stream:
             gen = self._stream_to_generator(
-                self._engine.query(
+                self._model.query(
                     image=image_bytes,
                     question=question,
                     reasoning=reasoning,
+                    spatial_refs=spatial_refs,
                     stream=True,
                     settings=engine_settings,
                 )
@@ -280,10 +387,11 @@ class PhotonVL(VLM):
             return {"answer": gen}
 
         result = self._run(
-            self._engine.query(
+            self._model.query(
                 image=image_bytes,
                 question=question,
                 reasoning=reasoning,
+                spatial_refs=spatial_refs,
                 stream=False,
                 settings=engine_settings,
             )
@@ -293,6 +401,40 @@ class PhotonVL(VLM):
             output["reasoning"] = result.output["reasoning"]
         return output
 
+    def chat(
+        self,
+        messages: List[ChatMessage],
+        stream: bool = False,
+        settings: Optional[SamplingSettings] = None,
+        reasoning: bool = False,
+    ) -> ChatOutput:
+        if stream:
+            return {
+                "message": self._stream_to_generator(
+                    self._model.chat(
+                        messages=messages,
+                        reasoning=reasoning,
+                        stream=True,
+                        settings=self._settings(settings),
+                    )
+                )
+            }
+
+        result = self._run(
+            self._model.chat(
+                messages=messages,
+                reasoning=reasoning,
+                stream=False,
+                settings=self._settings(settings),
+            )
+        )
+        return {
+            "message": result.output["message"],
+            "finish_reason": result.output.get(
+                "finish_reason", result.finish_reason
+            ),
+        }
+
     def detect(
         self,
         image: Union[Image.Image, EncodedImage],
@@ -301,7 +443,11 @@ class PhotonVL(VLM):
     ) -> DetectOutput:
         image_bytes = _image_to_bytes(image)
         result = self._run(
-            self._engine.detect(image_bytes, object, settings=self._settings(settings))
+            self._model.detect(
+                image=image_bytes,
+                object=object,
+                settings=self._settings(settings),
+            )
         )
         return {"objects": result.output["objects"]}
 
@@ -310,10 +456,16 @@ class PhotonVL(VLM):
         image: Union[Image.Image, EncodedImage],
         object: str,
         settings: Optional[SamplingSettings] = None,
+        spatial_refs: Optional[List[SpatialRef]] = None,
     ) -> PointOutput:
         image_bytes = _image_to_bytes(image)
         result = self._run(
-            self._engine.point(image_bytes, object, settings=self._settings(settings))
+            self._model.point(
+                image=image_bytes,
+                object=object,
+                settings=self._settings(settings),
+                spatial_refs=spatial_refs,
+            )
         )
         return {"points": result.output["points"]}
 
@@ -324,18 +476,29 @@ class PhotonVL(VLM):
         spatial_refs: Optional[List[SpatialRef]] = None,
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
-    ) -> SegmentOutput:
+    ) -> Union[SegmentOutput, SegmentStreamOutput]:
         image_bytes = _image_to_bytes(image)
+        if stream:
+            return self._segment_stream_to_generator(
+                self._model.segment(
+                    image=image_bytes,
+                    object=object,
+                    spatial_refs=spatial_refs,
+                    stream=True,
+                    settings=self._settings(settings),
+                )
+            )
+
         result = self._run(
-            self._engine.segment(
-                image_bytes,
-                object,
+            self._model.segment(
+                image=image_bytes,
+                object=object,
                 spatial_refs=spatial_refs,
                 settings=self._settings(settings),
             )
         )
         seg = result.output["segments"][0]
-        output: SegmentOutput = {"path": seg["path"]}
+        output: SegmentOutput = {"path": seg["svg_path"]}
         if seg.get("bbox"):
             output["bbox"] = seg["bbox"]
         return output

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -185,7 +185,11 @@ def _get_or_create_engine(
             _engine_cache[key] = (engine, loop, thread, 1)
 
     if loser is not None:
-        _stop_engine(*loser)
+        try:
+            _stop_engine(*loser)
+        except Exception:
+            _release_engine(key)
+            raise
         return winner_engine, winner_loop, winner_thread, key
 
     return engine, loop, thread, key
@@ -229,10 +233,11 @@ class PhotonVL(VLM):
 
     def close(self) -> None:
         """Release this client's reference to its shared local engine."""
-        key = self._engine_key
-        if key is None:
-            return
-        self._engine_key = None
+        with _cache_lock:
+            key = self._engine_key
+            if key is None:
+                return
+            self._engine_key = None
         _release_engine(key)
 
     @property
@@ -421,32 +426,30 @@ class PhotonVL(VLM):
         messages: List[ChatMessage],
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
-        reasoning: bool = False,
+        reasoning: Optional[bool] = None,
     ) -> ChatOutput:
+        prompt: dict[str, object] = {
+            "messages": messages,
+            "stream": stream,
+            "settings": self._settings(settings),
+        }
+        if reasoning is not None:
+            prompt["reasoning"] = reasoning
+
         if stream:
             return {
                 "message": self._stream_to_generator(
-                    self._model.chat(
-                        messages=messages,
-                        reasoning=reasoning,
-                        stream=True,
-                        settings=self._settings(settings),
-                    )
+                    self._model.chat(**prompt)
                 )
             }
 
-        result = self._run(
-            self._model.chat(
-                messages=messages,
-                reasoning=reasoning,
-                stream=False,
-                settings=self._settings(settings),
-            )
-        )
+        result = self._run(self._model.chat(**prompt))
         return {
             "message": result.output["message"],
-            "finish_reason": result.output.get(
-                "finish_reason", result.finish_reason
+            "finish_reason": (
+                result.output.get("finish_reason")
+                or result.finish_reason
+                or "stop"
             ),
         }
 

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -72,11 +72,12 @@ def _parse_model(model: str) -> tuple[str, Optional[str]]:
 
     "moondream3-preview" -> ("moondream3-preview", None)
     "moondream3-preview/ft_abc@1000" -> ("moondream3-preview", "ft_abc@1000")
+    "Qwen/Qwen3.5-4B" -> ("Qwen/Qwen3.5-4B", None)
     """
-    if "/" not in model:
-        return model, None
-    base, adapter = model.split("/", 1)
-    return base, adapter
+    base, separator, suffix = model.rpartition("/")
+    if separator and suffix.startswith("ft_"):
+        return base, suffix
+    return model, None
 
 
 def _build_settings(
@@ -233,6 +234,17 @@ class PhotonVL(VLM):
             return
         self._engine_key = None
         _release_engine(key)
+
+    @property
+    def model_id(self) -> str:
+        return self._model.model_id
+
+    @property
+    def tasks(self) -> tuple[str, ...]:
+        return self._model.tasks
+
+    def supports(self, task: str) -> bool:
+        return self._model.supports(task)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import os
 import queue
 import threading
 from io import BytesIO
@@ -78,10 +79,7 @@ def _build_settings(
     adapter: Optional[str] = None,
 ) -> Optional[dict]:
     """Map moondream SamplingSettings + adapter to kestrel settings dict."""
-    out: dict = {}
-    if settings is not None:
-        if "max_tokens" in settings:
-            out["max_tokens"] = settings["max_tokens"]
+    out: dict = dict(settings or {})
     if adapter is not None:
         out["adapter"] = adapter
     return out if out else None
@@ -90,8 +88,8 @@ def _build_settings(
 # ------------------------------------------------------------------
 # Singleton engine cache
 # ------------------------------------------------------------------
-# Keyed by (base_model, device, max_batch_size, kv_cache_pages) so that
-# PhotonVL instances differing only by adapter share the same engine.
+# PhotonVL instances differing only by adapter share an engine. Credentials
+# remain isolated because the engine owns the adapter provider for its key.
 
 _engine_cache: dict[tuple, tuple] = {}  # key -> (engine, loop, thread)
 _cache_lock = threading.Lock()
@@ -99,13 +97,14 @@ _cache_lock = threading.Lock()
 
 def _get_or_create_engine(
     base_model: str,
-    max_batch_size: int,
-    kv_cache_pages: Optional[int],
-    device: str,
+    runtime_config: dict,
     api_key: Optional[str] = None,
 ):
     """Return a shared (engine, loop, thread) for the given config."""
-    key = (base_model, device, max_batch_size, kv_cache_pages)
+    effective_api_key = (
+        api_key if api_key is not None else os.environ.get("MOONDREAM_API_KEY")
+    )
+    key = (base_model, tuple(sorted(runtime_config.items())), effective_api_key)
 
     with _cache_lock:
         if key in _engine_cache:
@@ -122,13 +121,11 @@ def _get_or_create_engine(
     try:
         cfg = RuntimeConfig(
             model=base_model,
-            max_batch_size=max_batch_size,
-            kv_cache_pages=kv_cache_pages,
-            device=device,
+            **runtime_config,
         )
 
         engine = asyncio.run_coroutine_threadsafe(
-            InferenceEngine.create(cfg, api_key=api_key), loop
+            InferenceEngine.create(cfg, api_key=effective_api_key), loop
         ).result()
     except Exception:
         loop.call_soon_threadsafe(loop.stop)
@@ -157,14 +154,13 @@ class PhotonVL(VLM):
         *,
         api_key: Optional[str] = None,
         model: str = "moondream3-preview",
-        max_batch_size: int = 4,
-        kv_cache_pages: Optional[int] = None,
-        device: Optional[str] = None,
+        **runtime_config,
     ):
         base_model, self._adapter = _parse_model(model)
-        device = _default_photon_device() if device is None else device
+        if runtime_config.get("device") is None:
+            runtime_config["device"] = _default_photon_device()
         self._engine, self._loop, self._thread = _get_or_create_engine(
-            base_model, max_batch_size, kv_cache_pages, device, api_key=api_key
+            base_model, runtime_config, api_key=api_key
         )
 
     # ------------------------------------------------------------------

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -100,17 +100,20 @@ _engine_cache: dict[tuple, tuple] = {}  # key -> (engine, loop, thread, refs)
 _cache_lock = threading.Lock()
 
 
-def _stop_engine(engine, loop, thread) -> None:
+def _stop_engine(engine, loop, thread, *, suppress_errors: bool = False) -> None:
+    failure = None
     if loop.is_running():
         try:
             asyncio.run_coroutine_threadsafe(
                 engine.shutdown(), loop
             ).result(timeout=30)
-        except Exception:
-            pass
+        except Exception as exc:
+            failure = exc
         finally:
             loop.call_soon_threadsafe(loop.stop)
     thread.join(timeout=30)
+    if failure is not None and not suppress_errors:
+        raise failure
 
 
 def _shutdown_cached_engines() -> None:
@@ -120,7 +123,7 @@ def _shutdown_cached_engines() -> None:
         _engine_cache.clear()
 
     for engine, loop, thread, _refs in entries:
-        _stop_engine(engine, loop, thread)
+        _stop_engine(engine, loop, thread, suppress_errors=True)
 
 
 atexit.register(_shutdown_cached_engines)

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -127,7 +127,11 @@ def _shutdown_cached_engines() -> None:
         _stop_engine(engine, loop, thread, suppress_errors=True)
 
 
-atexit.register(_shutdown_cached_engines)
+# Engine shutdown may perform async DNS during its final telemetry flush.
+# CPython tears down the shared thread-pool executor before normal atexit
+# callbacks, so clean up before thread shutdown when that hook is available.
+_register_shutdown = getattr(threading, "_register_atexit", atexit.register)
+_register_shutdown(_shutdown_cached_engines)
 
 
 def _get_or_create_engine(

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -55,6 +55,25 @@ QueryOutput = TypedDict(
     total=False
 )
 
+ChatMessage = TypedDict(
+    "ChatMessage",
+    {
+        "role": Literal["system", "user", "assistant"],
+        "content": object,
+        "reasoning": str,
+    },
+    total=False,
+)
+
+ChatOutput = TypedDict(
+    "ChatOutput",
+    {
+        "message": Union[ChatMessage, Generator[str, None, None]],
+        "finish_reason": str,
+    },
+    total=False,
+)
+
 Region = TypedDict(
     "Region", {"x_min": float, "y_min": float, "x_max": float, "y_max": float}
 )
@@ -254,6 +273,15 @@ SFTGroup = TypedDict(
 
 
 class VLM(ABC):
+    def close(self) -> None:
+        """Release backend resources held by this client."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
     @abstractmethod
     def encode_image(self, image: Union[Image.Image, EncodedImage]) -> EncodedImage:
         """
@@ -275,7 +303,7 @@ class VLM(ABC):
     def caption(
         self,
         image: Union[Image.Image, EncodedImage],
-        length: Literal["normal", "short"] = "normal",
+        length: Literal["normal", "short", "long"] = "normal",
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
     ) -> CaptionOutput:
@@ -284,7 +312,7 @@ class VLM(ABC):
 
         Args:
             image (Union[Image.Image, EncodedImage]): The input image to be captioned.
-            length (str): Length of caption to generate. Can be "normal" or "short".
+            length (str): Length of caption to generate. Can be "normal", "short", or "long".
                 Defaults to "normal".
             stream (bool): If True, returns a generator that streams the output tokens.
                 Defaults to False.
@@ -304,6 +332,7 @@ class VLM(ABC):
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
         reasoning: bool = False,
+        spatial_refs: Optional[List[SpatialRef]] = None,
     ) -> QueryOutput:
         """
         Generate an answer to the input question about the input image.
@@ -322,10 +351,21 @@ class VLM(ABC):
         """
 
     @abstractmethod
+    def chat(
+        self,
+        messages: List[ChatMessage],
+        stream: bool = False,
+        settings: Optional[SamplingSettings] = None,
+        reasoning: bool = False,
+    ) -> ChatOutput:
+        """Continue an OpenAI-style multi-turn conversation."""
+
+    @abstractmethod
     def detect(
         self,
         image: Union[Image.Image, EncodedImage],
         object: str,
+        settings: Optional[SamplingSettings] = None,
     ) -> DetectOutput:
         """
         Detect and localize the specified object in the input image.
@@ -333,6 +373,7 @@ class VLM(ABC):
         Args:
             image (Union[Image.Image, EncodedImage]): The input image to be analyzed.
             object (str): The object to be detected in the image.
+            settings (Optional[SamplingSettings]): Optional generation settings.
 
         Returns:
             DetectOutput: A dictionary containing:
@@ -349,6 +390,8 @@ class VLM(ABC):
         self,
         image: Union[Image.Image, EncodedImage],
         object: str,
+        settings: Optional[SamplingSettings] = None,
+        spatial_refs: Optional[List[SpatialRef]] = None,
     ) -> PointOutput:
         """
         Points out all instances of the given object in the input image.

--- a/moondream/types.py
+++ b/moondream/types.py
@@ -55,20 +55,23 @@ QueryOutput = TypedDict(
     total=False
 )
 
-ChatMessage = TypedDict(
-    "ChatMessage",
-    {
-        "role": Literal["system", "user", "assistant"],
-        "content": object,
-        "reasoning": str,
-    },
-    total=False,
-)
+class ChatMessage(TypedDict):
+    role: Literal["system", "user", "assistant"]
+    content: object
+
+
+class ChatReasoningDetails(TypedDict, total=False):
+    grounding: List[ReasoningGrounding]
+
+
+class ChatResponseMessage(ChatMessage, total=False):
+    reasoning: str
+    reasoning_details: ChatReasoningDetails
 
 ChatOutput = TypedDict(
     "ChatOutput",
     {
-        "message": Union[ChatMessage, Generator[str, None, None]],
+        "message": Union[ChatResponseMessage, Generator[str, None, None]],
         "finish_reason": str,
     },
     total=False,
@@ -356,7 +359,7 @@ class VLM(ABC):
         messages: List[ChatMessage],
         stream: bool = False,
         settings: Optional[SamplingSettings] = None,
-        reasoning: bool = False,
+        reasoning: Optional[bool] = None,
     ) -> ChatOutput:
         """Continue an OpenAI-style multi-turn conversation."""
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -412,58 +412,68 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "kestrel"
-version = "0.4.2"
-description = "a fast, efficient inference engine for moondream"
+version = "0.5.0"
+description = "A fast, efficient inference engine for vision-language models"
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "kestrel-0.4.2-py3-none-any.whl", hash = "sha256:592bf550ed9d9f1178b0198ad31b4986624ae68cf6e67e6533117cd0afa480d3"},
-    {file = "kestrel-0.4.2.tar.gz", hash = "sha256:4c5dd15270ea892cb14d8c8415dff03d111d25bb481939eee9a4a89da7b8fe7c"},
+    {file = "kestrel-0.5.0-py3-none-any.whl", hash = "sha256:96d14534b55bd28f0c41de78261fbcc4e2cfcb9fede7eb44c18ae23991c7e302"},
+    {file = "kestrel-0.5.0.tar.gz", hash = "sha256:abff1bf78ca8bb21f46faf0a6fc521601c4a125166ee7fbcb75929b178dfe227"},
 ]
 
 [package.dependencies]
 httpx = ">=0.27"
 huggingface-hub = ">=0.20"
-kestrel-kernels = "0.4.6"
-kestrel-native = "0.1.5"
+kestrel-kernels = "0.4.9"
+kestrel-native = "0.1.6"
+numpy = ">=1.26"
 safetensors = ">=0.4"
 tokenizers = ">=0.15"
-torch = ">=2.4"
+torch = [
+    {version = ">=2.8", markers = "platform_machine != \"aarch64\""},
+    {version = ">=2.4", markers = "platform_machine == \"aarch64\""},
+]
 torch-c-dlpack-ext = ">=0.1.3"
 
 [[package]]
 name = "kestrel-kernels"
-version = "0.4.6"
+version = "0.4.9"
 description = "CUDA kernel library for Kestrel"
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "kestrel_kernels-0.4.6-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:1028f994a8971ba55ad808bb5c8b58059bc43538f310d5aa8fab271d1383e825"},
-    {file = "kestrel_kernels-0.4.6-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:a474315d1ac4452a13ab36ffe1f7892f781ead2021d0f891bd974d64d87e864b"},
-    {file = "kestrel_kernels-0.4.6-cp310-cp310-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:3f4c5929c9eb13f440e64cd29b37a3c866b2ddc716a59d38b9c2f4026392d937"},
-    {file = "kestrel_kernels-0.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:5bc0f4ecfa3222d01803ea8630b051749ea5e76e3a918b0b0f949527c397d539"},
-    {file = "kestrel_kernels-0.4.6-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:52dc6f9aa70320cfb522e53d8ea9424648c9f73e6e8de72b839205e9a0dcdcfc"},
-    {file = "kestrel_kernels-0.4.6-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:03b46ff0057e843f84c54e25a822fb18677652fdd64c622593b7f1050748b6ab"},
-    {file = "kestrel_kernels-0.4.6-cp311-cp311-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:48825e2ce309dcb433def71ff78fb8bb5c0f4f9d21339a8c91304e3f79f45377"},
-    {file = "kestrel_kernels-0.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:8ecb121829d7e724f37587e901a9c8593852ef4974261d04e0d350ae398879f5"},
-    {file = "kestrel_kernels-0.4.6-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:d75064a4dd26c12959de68a8614ba8b7ad9d4268070904e72d5c50b609fa3934"},
-    {file = "kestrel_kernels-0.4.6-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:2214c5a5e7ee958e0af0927782206727e5b8f7e9ffae535bfb34e219eaaeafcc"},
-    {file = "kestrel_kernels-0.4.6-cp312-cp312-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:0decd77cfdef2f1b796754e2d256a811bdd577acbf34663b99060a69a58b8851"},
-    {file = "kestrel_kernels-0.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:21e300e034a4765d16f438be2cce80f4ed3bb34212e3562bb36774396f546c51"},
-    {file = "kestrel_kernels-0.4.6-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:cf625fa4bcc1ce85c65e85abc5bd684c67f009c8703887d14144e0a6bfbdca1d"},
-    {file = "kestrel_kernels-0.4.6-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:bcf0518988d67658117aee06ebac2a1a56bbd42419358341166c9fcf62eead7d"},
-    {file = "kestrel_kernels-0.4.6-cp313-cp313-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:d5be9c27293cb2f0a7f1acb0fbce282a4c81e8747c82763b9c49b9ebb51c1510"},
-    {file = "kestrel_kernels-0.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:4e3ffaf690a7b67e62a1c3cf532c84d5e36562968d285270092fb64befcd534a"},
-    {file = "kestrel_kernels-0.4.6-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:f97df03ad74601ab0e2b63c072f0255d23413ac99d39b2192a002b8d973c6174"},
-    {file = "kestrel_kernels-0.4.6-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:7f60b61f462909ecadb3b6e10796b453d0599854b5f93a4b9047123e64162f1a"},
-    {file = "kestrel_kernels-0.4.6-cp314-cp314-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:205cccf16e8808b1cdecea0a5697404612b6e11d553191355476d6f8746a38d3"},
-    {file = "kestrel_kernels-0.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:8562c17626f49062cbba612a5c11b97561b5aa1cf14f82ce14748e05ae3db1da"},
+    {file = "kestrel_kernels-0.4.9-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:9019172e3b69efc3e8463591d0f12cd6140eaf41407c770d7d153d86ed191809"},
+    {file = "kestrel_kernels-0.4.9-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:6ffb10b2483db590b632d107c9e3dae6c7a239fd362f420d36e4bffa2d481949"},
+    {file = "kestrel_kernels-0.4.9-cp310-cp310-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:c52d46d5bf43e9d667470d99902e8c0ae0319d49a5178a3859fb1b8c63440dd3"},
+    {file = "kestrel_kernels-0.4.9-cp310-cp310-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:451e9fc8a42dbc08bfa3f4b757c3e014b2fcde6aea9fbc208bad8ae7fcbf555f"},
+    {file = "kestrel_kernels-0.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:ee0b74e976d678ec8f9da580acf84d91df6e5d3019b507fed39b295848b9a478"},
+    {file = "kestrel_kernels-0.4.9-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:fb12d5bee22fc0c26b2944b6b746af1ddaa2c7859121462dec0e93201bc903f6"},
+    {file = "kestrel_kernels-0.4.9-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:f05ce9c6b2c3660924eadeab6e75432642be33a94e978589955da99bf68fe793"},
+    {file = "kestrel_kernels-0.4.9-cp311-cp311-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:7c23e5389f3bab02c397b2654ebea23b011dbcb6089d7b1bdd44a02e670fe4f2"},
+    {file = "kestrel_kernels-0.4.9-cp311-cp311-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:a3eb0bf9a96e0d3723160367341f2f30759cd36aa3563d44ddc97b0e4125a8cc"},
+    {file = "kestrel_kernels-0.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:907d0d27f5d87132542dd1b0847f78095fe09bdb98bebcd0310ae54e675e5534"},
+    {file = "kestrel_kernels-0.4.9-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:2d2329c7e235e82807e3b98e8785d2159361592eb39ab1bb42c6b9b4048dc46d"},
+    {file = "kestrel_kernels-0.4.9-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:d7f5a4cd7302b913f2369cdbb69c9e5613328d7728b1bdd113c2c4bc42ef4a27"},
+    {file = "kestrel_kernels-0.4.9-cp312-cp312-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:e70c4d53c40794837ff0401f13fef0f31eb5175fae748fa9ca9c2e8e467c6100"},
+    {file = "kestrel_kernels-0.4.9-cp312-cp312-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:1356d499ca0fec6292b78974884456ca2453600a3d42db75fe6b2d9aa070bb81"},
+    {file = "kestrel_kernels-0.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:7157c600b256e503b997e00a9e5cd9f348fb4f294f13c3df419cd5c9040a1261"},
+    {file = "kestrel_kernels-0.4.9-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:f53b915daa157ad5e0424d1270bead336c1f2f9911522614138dcddfd9cf6136"},
+    {file = "kestrel_kernels-0.4.9-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:938882b45343f39644bfc229c43b34bcfe0b4327289b3328fb57431bc66dac3d"},
+    {file = "kestrel_kernels-0.4.9-cp313-cp313-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:2b01296a79c274fb0777e0931b131fee9fcce43c400503d9e759c4ac831c9907"},
+    {file = "kestrel_kernels-0.4.9-cp313-cp313-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:9a36e12b63c9c2a5dd4044eab6c8c425254a9712168e17ba91253cd04902bab7"},
+    {file = "kestrel_kernels-0.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:8639bfdcc558b9f28a8453aedd185a85a23a0b092e26d1f36845b65cfde65336"},
+    {file = "kestrel_kernels-0.4.9-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:0aab309ec71c22cadee13424add616bffc275b5bd14ae106bb424ee0a79535c0"},
+    {file = "kestrel_kernels-0.4.9-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:e3a8a9456650d7b3936b0c8ffc972387eacda15bd05f877c4d2fef1e6ffdde78"},
+    {file = "kestrel_kernels-0.4.9-cp314-cp314-manylinux_2_34_aarch64.manylinux_2_35_aarch64.whl", hash = "sha256:cf5e426e3019da4d807814625d9efd2991222514902d605e7de66b2d9f0431b8"},
+    {file = "kestrel_kernels-0.4.9-cp314-cp314-manylinux_2_34_x86_64.manylinux_2_35_x86_64.whl", hash = "sha256:e5b877d4d24b5fe8048a3c08302ad2be8a4b87e43c14ce6a65d91ef1c5008a74"},
+    {file = "kestrel_kernels-0.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:127f641abe5295935cb907ced503be07a5830f561f4f56450ff36dfcb135e524"},
 ]
 
 [package.dependencies]
 kestrel-mps-torch-ext = {version = ">=0.1.1", markers = "sys_platform == \"darwin\""}
+numpy = "*"
 packaging = "*"
 torch-c-dlpack-ext = "*"
 
@@ -491,42 +501,42 @@ packaging = "*"
 
 [[package]]
 name = "kestrel-native"
-version = "0.1.5"
+version = "0.1.6"
 description = "High-performance native extensions for Kestrel"
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "kestrel_native-0.1.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a889ac6ea63338e4ba4e8ad875fa76aa0c5dbf9760b5dddf2bc73cb4e5aa5e54"},
-    {file = "kestrel_native-0.1.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:99f511e8e8871a7ff3acd5a3727f7468410c3c2d3c991b35c0b9fd515e9dcd98"},
-    {file = "kestrel_native-0.1.5-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1a2e29e0cad7b06a66834a73ded7dd1e3b323046ceb8903aed6fa9d1dd4334f8"},
-    {file = "kestrel_native-0.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a164cc581fbb578442453f0acb3c0ebf54b3fa4d5f5e493b362763e1a423ed73"},
-    {file = "kestrel_native-0.1.5-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:881bb3e527dffe56c62c77eca61d86e492f827395db2169cdf955f4981f5ad50"},
-    {file = "kestrel_native-0.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:ef0a9a0ac891595e2a64b926116565c26de197ada694f85e76677ea2d468c5aa"},
-    {file = "kestrel_native-0.1.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0a92a286d814cda35517fa49745f64b37ca9ec463d865adbd7f29000d5b8e642"},
-    {file = "kestrel_native-0.1.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbd407155e9ff7bda1bd6be8dbd3277ef40952589c95601b5cb3116051931bbc"},
-    {file = "kestrel_native-0.1.5-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9d4a3e062256d81b33f4ed7a035cf5ac15dabfcdd5d5254b90229e861ff8d83a"},
-    {file = "kestrel_native-0.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4828f00cfc2539903ae4540fa170ef68b070782cf385951067b54edd2181ecdc"},
-    {file = "kestrel_native-0.1.5-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:298778e29dec60f2b2771865e2c2b3ca485c60914730d339cb71bd480551e884"},
-    {file = "kestrel_native-0.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:91ae40a2adcb1a34b7771766c4fdf6f892226265669d6f8db6f79af002e36d3f"},
-    {file = "kestrel_native-0.1.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:10ff7f8287b2f7a1c043dc9258177a68123d703c1b42452a9746f6389fe359e9"},
-    {file = "kestrel_native-0.1.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdcd74e8416b624b4b8cb8c2a13826b3d6dff56fb1ea357218ffe20f5b5fdd04"},
-    {file = "kestrel_native-0.1.5-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:60b7b570701d469856dcd9076751f8367a6a55046a622951b762155845dce2a3"},
-    {file = "kestrel_native-0.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fcfcfb8975c64b915de69405fcf7e570c6bd53ad70061dbbdfea50496bfc3e9"},
-    {file = "kestrel_native-0.1.5-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f9f0d0651a0522e4787006301b878bc226dfdb1c98ce2677e0bb4a722494f84c"},
-    {file = "kestrel_native-0.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:18e6b370fe9d2d893e6ebcda14850e1fcfeb11aa9754c8210367a1f94c23f336"},
-    {file = "kestrel_native-0.1.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b38ddfd21e19cf25993c028c2625718b5f21919696e6331f83619794fb7c4826"},
-    {file = "kestrel_native-0.1.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9369dccbc5c1d95aaebf40f9185feef34982eee66b29c58498208a1df59edcf4"},
-    {file = "kestrel_native-0.1.5-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:96a2911fc61509ce7cb4433432dc5cafec7db86a602564a5aeb1af7bb0831df4"},
-    {file = "kestrel_native-0.1.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8515831c1edda3a778725e4214c9c850f4b9ce01dd34e889b85d94f2185d98d"},
-    {file = "kestrel_native-0.1.5-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:dba964c82ea24be2e4e401761de59bc043b42cb5b5da2abb72fb9be89876242f"},
-    {file = "kestrel_native-0.1.5-cp313-cp313-win_amd64.whl", hash = "sha256:8eed5a195d9a0e64defab09b52eb906f4fb38a34ddd7c7bc16cf7bd0550c2cf9"},
-    {file = "kestrel_native-0.1.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a7cad074660ab69691f80b6c979d5a0ad847c9dbafc64b0721c36b5eb95adcfd"},
-    {file = "kestrel_native-0.1.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95d23234b52e1b50daa01e69f7c01c033790bab62a4743373af0867755745f62"},
-    {file = "kestrel_native-0.1.5-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5f17bcf5f795f992a1eceffbfc1c94711031421c5b72770f0ac734024b9e85b9"},
-    {file = "kestrel_native-0.1.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0121d072a8f2bf963aa5738e10c1153f686cb0b78ee9f8d2938de3422558a622"},
-    {file = "kestrel_native-0.1.5-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b57d2568a35806c815d278fa20131ffb9a483fcd1f9dad38a64878294cdc91cc"},
-    {file = "kestrel_native-0.1.5-cp314-cp314-win_amd64.whl", hash = "sha256:284ae3c5546b065b72e378226fe5e131347709202fabb0c51e610b5ccd2d95e3"},
+    {file = "kestrel_native-0.1.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c264282f4fe9d476aa28dcb93b643790f8d273253b59a1553cfaf4c6bc6a0668"},
+    {file = "kestrel_native-0.1.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1bef0fd43a559485903f442ebe1a97f0dafeee02156ee62c9bb8a19f49d224d0"},
+    {file = "kestrel_native-0.1.6-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:554d6e59b956f034c0b7c6716fe56baa2dd870ba86a7ccaf476e358b9d1deebf"},
+    {file = "kestrel_native-0.1.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3831d6032d16a3045166c83549bbb600ef8eebe5f4c5bef42c9bb3c97b6e02"},
+    {file = "kestrel_native-0.1.6-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4134f7235d7f628671127878f2b6313885388c858acc9f36eedf9cde01a3f199"},
+    {file = "kestrel_native-0.1.6-cp310-cp310-win_amd64.whl", hash = "sha256:5c3028fa8a43ad34d957cfaa132899d747af5d2b090d8fa4e4f89643f999f784"},
+    {file = "kestrel_native-0.1.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4285558f6dee6dfe95b866be32d73495baa2dad3dd20dae1b1a3e7d093b3b283"},
+    {file = "kestrel_native-0.1.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:46b1107c239431dda54f07adedba4190c63c482984eb0e1fbfa8c2b3ab1e5cc4"},
+    {file = "kestrel_native-0.1.6-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f3e6cc15a9b04e2a5131b326aad821a6d76f9628dcc1da2506afa96c2ddf40bb"},
+    {file = "kestrel_native-0.1.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58b47f070edf53a3d24458c790aa5c3c55c9cebd661d61eaac7e77cd6f214a31"},
+    {file = "kestrel_native-0.1.6-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:baace95ea759f5948d7a09af6b83352226ddfcfb572ce5dba5bc20ed70706549"},
+    {file = "kestrel_native-0.1.6-cp311-cp311-win_amd64.whl", hash = "sha256:05077c5b9d65698ca4abd2f11a522bdf095eebc148b24f15987544b1f9626aa1"},
+    {file = "kestrel_native-0.1.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:345a677169c0880fbb0f22c7343a034c0d1c55551d8f4633d77b85ac40e4fd94"},
+    {file = "kestrel_native-0.1.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fb4836c2a4b47f7825d289f06c68f803cab3bdea8ce18a2eaed07dbb19593c92"},
+    {file = "kestrel_native-0.1.6-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b5ac0b364f3b39bf8da95ff61a883f2be2d548b2054137b3b55508d66a3e2abb"},
+    {file = "kestrel_native-0.1.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf20576bcdd784feb0381954ed0e0b03f098abd7860853757b517afbe3ec4950"},
+    {file = "kestrel_native-0.1.6-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1d32afe15b97fa2b08688f9bb635d1c6c21c97c8ba3c0668e79121b987a3d374"},
+    {file = "kestrel_native-0.1.6-cp312-cp312-win_amd64.whl", hash = "sha256:8794988a09d75c26113adeba99e06e3f0119aaad8a25cd960e4c3cb5ad9c9a22"},
+    {file = "kestrel_native-0.1.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:fd78cb4f9959953a58e071c878a11c4d4eaf2ec1ece7381d58cbb7467cd9cf2b"},
+    {file = "kestrel_native-0.1.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:57f1eeaa516bbbbf03064d7266866390545dbde92fa337d964e247f7b1fc36bd"},
+    {file = "kestrel_native-0.1.6-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd50c944cf54bdfae54cb0ccfff433eeed7cff00d57df0ab4e0ed9a51e2b97d1"},
+    {file = "kestrel_native-0.1.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:730ff3b06a50bb6baffd016eebf475caa67404d07184bd012e30a4e8fae163e0"},
+    {file = "kestrel_native-0.1.6-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3341efc4bba8d82ac95368074c31509ff6451847db973d9c70903fcca983189f"},
+    {file = "kestrel_native-0.1.6-cp313-cp313-win_amd64.whl", hash = "sha256:04bd5a420414f9ce1770cb525fa584b9da3ffbc8da858335eb29911d2c9f6d1e"},
+    {file = "kestrel_native-0.1.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:40dff70acb3c7fafdeabb76d344e3a0fa27f726d893228fcd3ae5f03cdcdb3d0"},
+    {file = "kestrel_native-0.1.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:642ebb3f6fee0d3a4b82856fbfc86ff794639e3e8cb5f03b1dd3129ec5802f4a"},
+    {file = "kestrel_native-0.1.6-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:39912e533b8f26eac441fd36c80f3657bf2956f0bd6eed86fadba9ff8090e67e"},
+    {file = "kestrel_native-0.1.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a89f8e73e117d56a1eef321bbc3dc37329f80da3a1496f70e18daeb2d1fc5df9"},
+    {file = "kestrel_native-0.1.6-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c5cf299befa249e1e4a8d20d2edcec68fdc87f28ecead5d0811349b277d869c2"},
+    {file = "kestrel_native-0.1.6-cp314-cp314-win_amd64.whl", hash = "sha256:d1d8499395f1649d5c234a42547cc20b55e9a1e87d37ff23c7e13686b09241d9"},
 ]
 
 [package.dependencies]
@@ -1537,4 +1547,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "e328d9d3c0305713b6fdbf6db90de357bd4bff9748fd41d6e750f54d1ec31db4"
+content-hash = "b80660601624264e0d0a9a943f9bd72182db562dfc3d95793fcc5e33e4a8da63"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "moondream"
-version = "1.3.0"
+version = "2.0.0"
 description = "Official Python client for Moondream, a fast and efficient vision language model."
 authors = [ "M87 Labs <contact@moondream.ai>",]
 readme = "README.md"
@@ -19,5 +19,5 @@ reportMissingParameterType = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-pillow = "^10.4.0"
-kestrel = "^0.4.2"
+pillow = ">=10.4.0"
+kestrel = "0.5.0"

--- a/test_cloud.py
+++ b/test_cloud.py
@@ -1,7 +1,52 @@
 import sys
 import os
+import json
+
 import moondream as md
 from PIL import Image
+
+
+def test_cloud_chat_preserves_service_reasoning_default(monkeypatch):
+    payloads = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return None
+
+        def read(self):
+            return json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "answer",
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ).encode()
+
+    def fake_urlopen(request):
+        payloads.append(json.loads(request.data))
+        return FakeResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = md.vl(api_key="key")
+
+    result = client.chat([{"role": "user", "content": "question"}])
+    client.chat(
+        [{"role": "user", "content": "question"}],
+        reasoning=False,
+    )
+
+    assert "reasoning" not in payloads[0]
+    assert payloads[1]["reasoning"] is False
+    assert result["finish_reason"] == "stop"
 
 
 def main(image_path: str):

--- a/test_local.py
+++ b/test_local.py
@@ -1,8 +1,11 @@
 import sys
 import os
+import asyncio
+from types import SimpleNamespace
+
 import moondream as md
 from PIL import Image
-from moondream.photon_vl import _parse_model
+from moondream.photon_vl import PhotonVL, _parse_model
 
 
 def test_model_parser_preserves_registered_repository_ids():
@@ -46,6 +49,36 @@ def test_vl_local_delegates_to_photon(monkeypatch):
         "api_key": "key",
         "runtime_config": {"max_batch_size": 8},
     }
+
+
+def test_photon_chat_preserves_model_reasoning_default():
+    calls = []
+
+    class FakeModel:
+        async def chat(self, **prompt):
+            calls.append(prompt)
+            return SimpleNamespace(
+                output={
+                    "message": {"role": "assistant", "content": "answer"},
+                    "finish_reason": None,
+                },
+                finish_reason=None,
+            )
+
+    client = object.__new__(PhotonVL)
+    client._adapter = None
+    client._model = FakeModel()
+    client._run = asyncio.run
+
+    result = client.chat([{"role": "user", "content": "question"}])
+    client.chat(
+        [{"role": "user", "content": "question"}],
+        reasoning=False,
+    )
+
+    assert "reasoning" not in calls[0]
+    assert calls[1]["reasoning"] is False
+    assert result["finish_reason"] == "stop"
 
 
 def main(image_path: str):

--- a/test_local.py
+++ b/test_local.py
@@ -2,6 +2,50 @@ import sys
 import os
 import moondream as md
 from PIL import Image
+from moondream.photon_vl import _parse_model
+
+
+def test_model_parser_preserves_registered_repository_ids():
+    assert _parse_model("Qwen/Qwen3.5-4B") == ("Qwen/Qwen3.5-4B", None)
+    assert _parse_model("google/gemma-4-E2B-it") == (
+        "google/gemma-4-E2B-it",
+        None,
+    )
+
+
+def test_model_parser_extracts_explicit_finetune_suffix():
+    assert _parse_model("moondream3-preview/ft_abc@1000") == (
+        "moondream3-preview",
+        "ft_abc@1000",
+    )
+
+
+def test_vl_local_delegates_to_photon(monkeypatch):
+    captured = {}
+
+    def fake_photon(model, *, api_key=None, **runtime_config):
+        captured.update(
+            model=model,
+            api_key=api_key,
+            runtime_config=runtime_config,
+        )
+        return "photon"
+
+    monkeypatch.setattr(md, "photon", fake_photon)
+
+    result = md.vl(
+        api_key="key",
+        local=True,
+        model="Qwen/Qwen3.5-4B",
+        max_batch_size=8,
+    )
+
+    assert result == "photon"
+    assert captured == {
+        "model": "Qwen/Qwen3.5-4B",
+        "api_key": "key",
+        "runtime_config": {"max_batch_size": 8},
+    }
 
 
 def main(image_path: str):

--- a/test_local.py
+++ b/test_local.py
@@ -16,7 +16,7 @@ def main(image_path: str):
         sys.exit(1)
 
     # Instantiate the client in local mode.
-    client = md.vl(endpoint="http://localhost:2020/v1")
+    client = md.vl(local=True)
 
     # Test the caption method.
     try:


### PR DESCRIPTION
## Summary

- release Moondream 2.0.0 with an exact Kestrel 0.5.0 dependency
- add md.photon(model) as the explicit local multi-model interface while keeping md.vl(local=True) fully supported
- expose every Kestrel 0.5 model family, including Moondream, Qwen 3.5/3.6, and Gemma 4, without requiring customers to import Kestrel
- route every Photon capability through Kestrel generic ModelHandle instead of maintaining engine-specific call paths
- expose model discovery, model identity, task discovery, capability checks, multi-turn chat, spatial references, and streamed segmentation
- preserve each model or Cloud service's reasoning default unless the caller explicitly overrides it
- pass runtime configuration and sampling settings through without wrapper-owned field lists
- isolate cached local engines by effective credential and add reference-counted deterministic cleanup, including concurrent close and construction-failure handling

## Verification

- python -m pytest -q (34 passed)
- Python compile and diff checks
- concurrent close stress: 16 callers produced exactly one reference release
- built wheel metadata: moondream 2.0.0, kestrel 0.5.0, pillow >=10.4.0
- wheel contains only the client modules, example image, and package metadata
- installed-wheel H100 smoke using exact kestrel 0.5.0, kestrel-kernels 0.4.9, kestrel-native 0.1.6, AOT-only execution
- installed-wheel H100 process-exit smoke without explicit close; final telemetry and engine shutdown completed without warnings or tracebacks
- md.photon with Qwen/Qwen3.5-0.8B reported query/chat and returned a correct image answer
- md.photon with google/gemma-4-E2B-it reported query and returned a correct image answer
- legacy md.vl(local=True, model=...) was separately validated through the same path
- MD3 chat, ordinary segmentation, streamed segmentation, and deterministic close complete cleanly

The selected MD3 segmentation smoke prompt returned a bbox and no SVG tokens in the raw Kestrel skill result. Ordinary and streamed wrapper modes match exactly; no wrapper fallback or synthesized path was added.
