### PR TITLE
Fix Photon finetune checkpoint parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1
+
+- Fixed Photon local inference for finetuned checkpoints whose IDs use the
+  current ULID format.
+
 ## 2.0.0
 
 - Upgraded Photon local inference to `kestrel 0.5.0`. Moondream 2 and

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -71,11 +71,12 @@ def _parse_model(model: str) -> tuple[str, Optional[str]]:
     """Parse a model string into (base_model, adapter).
 
     "moondream3-preview" -> ("moondream3-preview", None)
-    "moondream3-preview/ft_abc@1000" -> ("moondream3-preview", "ft_abc@1000")
+    "moondream3-preview/01HXYZ@1000" -> ("moondream3-preview", "01HXYZ@1000")
     "Qwen/Qwen3.5-4B" -> ("Qwen/Qwen3.5-4B", None)
     """
     base, separator, suffix = model.rpartition("/")
-    if separator and suffix.startswith("ft_"):
+    finetune_id, checkpoint_separator, step = suffix.rpartition("@")
+    if separator and checkpoint_separator and finetune_id and step.isdigit():
         return base, suffix
     return model, None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "moondream"
-version = "2.0.0"
+version = "2.0.1"
 description = "Official Python client for Moondream, a fast and efficient vision language model."
 authors = [ "M87 Labs <contact@moondream.ai>",]
 readme = "README.md"

--- a/test_local.py
+++ b/test_local.py
@@ -17,9 +17,24 @@ def test_model_parser_preserves_registered_repository_ids():
 
 
 def test_model_parser_extracts_explicit_finetune_suffix():
+    assert _parse_model("moondream3-preview/01HXYZ@1000") == (
+        "moondream3-preview",
+        "01HXYZ@1000",
+    )
     assert _parse_model("moondream3-preview/ft_abc@1000") == (
         "moondream3-preview",
         "ft_abc@1000",
+    )
+
+
+def test_model_parser_rejects_malformed_finetune_suffixes():
+    assert _parse_model("moondream3-preview/01HXYZ") == (
+        "moondream3-preview/01HXYZ",
+        None,
+    )
+    assert _parse_model("moondream3-preview/01HXYZ@latest") == (
+        "moondream3-preview/01HXYZ@latest",
+        None,
     )
 
 


### PR DESCRIPTION
## Summary
- recognize documented ULID checkpoint IDs in Photon local inference
- retain legacy `ft_` checkpoint compatibility and preserve repository model IDs
- prepare a 2.0.1 patch release

## Verification
- `35 passed` across `test_cloud.py`, `test_finetune.py`, and `test_local.py`
- `git diff --check`