### PR TITLE
Require explicit Photon model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ from PIL import Image
 model = md.vl(api_key="<your-api-key>")
 
 # Or initialize Photon local inference (NVIDIA GPU or Apple Silicon)
-model = md.photon("moondream3-preview")
+model = md.photon("moondream3.1-9B-A2B")
 
 # Load an image
 image = Image.open("path/to/image.jpg")
@@ -87,7 +87,7 @@ print(chat["message"]["content"])
 
 ```python
 model = md.vl(api_key="<your-api-key>")                        # Cloud
-model = md.photon("moondream3-preview")                        # Photon with Moondream 3
+model = md.photon("moondream3.1-9B-A2B")                       # Photon with Moondream 3.1
 model = md.vl(api_key="<your-api-key>", model="moondream3-preview/ft_id@step")  # Finetune
 qwen = md.photon("Qwen/Qwen3.5-4B")
 gemma = md.photon("google/gemma-4-E2B-it")
@@ -95,7 +95,7 @@ gemma = md.photon("google/gemma-4-E2B-it")
 
 Photon clients share matching local engines. Call `model.close()` when an
 application is finished with a client, or use
-`with md.photon("moondream3-preview") as model:`
+`with md.photon("moondream3.1-9B-A2B") as model:`
 for deterministic GPU and worker cleanup.
 
 ### Methods

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Photon local inference includes all models bundled with Kestrel 0.5:
 Use `md.photon_models()` to inspect the exact registered identifiers in the installed
 release. The returned client reports `model_id`, `tasks`, and
 `supports(task)` without requiring a Kestrel import.
-Existing `md.vl(local=True, ...)` calls remain supported and delegate to
-`md.photon(...)`.
+Existing `md.vl(local=True, model=..., ...)` calls remain supported and delegate
+to `md.photon(...)`.
 
 ## Installation
 
@@ -55,7 +55,7 @@ from PIL import Image
 model = md.vl(api_key="<your-api-key>")
 
 # Or initialize Photon local inference (NVIDIA GPU or Apple Silicon)
-model = md.photon()
+model = md.photon("moondream3-preview")
 
 # Load an image
 image = Image.open("path/to/image.jpg")
@@ -87,14 +87,15 @@ print(chat["message"]["content"])
 
 ```python
 model = md.vl(api_key="<your-api-key>")                        # Cloud
-model = md.photon()                                            # Photon with Moondream 3
+model = md.photon("moondream3-preview")                        # Photon with Moondream 3
 model = md.vl(api_key="<your-api-key>", model="moondream3-preview/ft_id@step")  # Finetune
 qwen = md.photon("Qwen/Qwen3.5-4B")
 gemma = md.photon("google/gemma-4-E2B-it")
 ```
 
 Photon clients share matching local engines. Call `model.close()` when an
-application is finished with a client, or use `with md.photon() as model:`
+application is finished with a client, or use
+`with md.photon("moondream3-preview") as model:`
 for deterministic GPU and worker cleanup.
 
 ### Methods

--- a/moondream/__init__.py
+++ b/moondream/__init__.py
@@ -18,7 +18,7 @@ def photon_models() -> list[str]:
 
 
 def photon(
-    model: str = "moondream3-preview",
+    model: str,
     *,
     api_key: Optional[str] = None,
     **runtime_config,
@@ -37,6 +37,7 @@ def vl(
     api_key: Optional[str] = None,
     endpoint: Optional[str] = DEFAULT_ENDPOINT,
     local: bool = False,
+    model: Optional[str] = None,
     **kwargs,
 ):
     """
@@ -46,17 +47,17 @@ def vl(
         api_key (str): Your API key for the remote (cloud) API.
         endpoint (str): The endpoint which you would like to call. Local is http://localhost:2020/v1 by default.
         local (bool): If True, delegate to ``photon()`` instead of the Cloud API.
+        model (str): Model identifier. Required for local Photon inference.
         **kwargs: Additional arguments forwarded to the selected backend. In local mode,
-            arguments other than ``model`` are passed directly to Kestrel's
-            ``RuntimeConfig``.
+            arguments are passed directly to Kestrel's ``RuntimeConfig``.
 
     Returns:
         An instance of CloudVL or PhotonVL.
     """
     if local:
-        model = kwargs.pop("model", "moondream3-preview")
+        if model is None:
+            raise TypeError("vl(local=True) requires model=<model identifier>")
         return photon(model, api_key=api_key, **kwargs)
-    model = kwargs.pop("model", None)
     return CloudVL(api_key=api_key, endpoint=endpoint, model=model, **kwargs)
 
 

--- a/moondream/photon_vl.py
+++ b/moondream/photon_vl.py
@@ -221,8 +221,8 @@ class PhotonVL(VLM):
     def __init__(
         self,
         *,
+        model: str,
         api_key: Optional[str] = None,
-        model: str = "moondream3-preview",
         **runtime_config,
     ):
         base_model, self._adapter = _parse_model(model)

--- a/test_local.py
+++ b/test_local.py
@@ -66,6 +66,24 @@ def test_vl_local_delegates_to_photon(monkeypatch):
     }
 
 
+def test_vl_local_requires_model():
+    try:
+        md.vl(local=True)
+    except TypeError as exc:
+        assert str(exc) == "vl(local=True) requires model=<model identifier>"
+    else:
+        raise AssertionError("local Photon inference accepted no model")
+
+
+def test_photon_requires_model():
+    try:
+        md.photon()
+    except TypeError as exc:
+        assert "model" in str(exc)
+    else:
+        raise AssertionError("Photon accepted no model")
+
+
 def test_photon_chat_preserves_model_reasoning_default():
     calls = []
 
@@ -108,7 +126,7 @@ def main(image_path: str):
         sys.exit(1)
 
     # Instantiate the client in local mode.
-    client = md.vl(local=True)
+    client = md.vl(local=True, model="moondream3-preview")
 
     # Test the caption method.
     try:

--- a/test_local.py
+++ b/test_local.py
@@ -126,7 +126,7 @@ def main(image_path: str):
         sys.exit(1)
 
     # Instantiate the client in local mode.
-    client = md.vl(local=True, model="moondream3-preview")
+    client = md.vl(local=True, model="moondream3.1-9B-A2B")
 
     # Test the caption method.
     try:


### PR DESCRIPTION
## Summary
- require a model identifier when constructing `md.photon(...)` or `PhotonVL`
- require `model=` on the backward-compatible `md.vl(local=True, ...)` path
- update local-inference examples so none relies on an implicit Moondream 3 preview selection

Cloud `md.vl(...)` behavior is unchanged; its model remains optional and may be selected by the service.

## Verification
- `python -m pytest test_local.py -q` (7 passed)
- `UV_CACHE_DIR=$PWD/.uv-cache uv build --wheel`